### PR TITLE
Fix deploying locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ protoc --go_out=../protogen --go_opt=paths=source_relative \
 ## Minikube/Local
 
 ```
-kubectl apply -k ./base/local
+kubectl apply -k overlays/local
 ```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 This repository contains different microservices and Kubernetes manifests to deploy them.
 Each microservice has it's own `app.yaml` that should contain all of it's dependencies (besides other microservices).
 
+To deploy on GKE, run:
+```
+kubectl apply -k overlays/gke
+```
+
 
 ## SQS
 

--- a/base/ip-visit-counter.yaml
+++ b/base/ip-visit-counter.yaml
@@ -64,8 +64,6 @@ spec:
           value: "http://ip-info"
         - name: IPINFOGRPCADDRESS
           value: "ip-info-grpc:5001"
-        - name: SQSQUEUENAME
-          value: "IpCount"
         - name: AWS_DEFAULT_REGION
           value: "eu-north-1"
         - name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
The application code relies on the presence of the queue name env var to determine if to require a connection to SQS or not.
That env var is added in a patch for gke, so should not be present in the base manifest.

Also documented deployment commands in readme.