### PR TITLE
fix invalid deployment yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ ip-visit-sqs-consumer/ip-visit-sqs-consumer
 # The localstack helm charts get cloned when creating the localstack setup.
 overlays/localstack/charts
 
+# Helm charts that are used in base (like kafka) get cloned there when installing the chart.
+base/charts
+
 .idea
 .vscode
 

--- a/base/visualization-frontend/deployment.yaml
+++ b/base/visualization-frontend/deployment.yaml
@@ -16,10 +16,10 @@ spec:
           image: ghcr.io/metalbear-co/visualization-frontend:latest
           imagePullPolicy: Always
           env:
-        - name: PORT
-          value: "3000"
-        - name: NEXT_PUBLIC_VISUALIZATION_BACKEND_URL
-          value: "/visualization/api"
+            - name: PORT
+              value: "3000"
+            - name: NEXT_PUBLIC_VISUALIZATION_BACKEND_URL
+              value: "/visualization/api"
           ports:
             - containerPort: 3000
               protocol: TCP


### PR DESCRIPTION
Before the fix, applying the resources results in

```
Error from server (BadRequest): error when creating "STDIN": Deployment in version "v1" cannot be handled as a Deployment: strict decoding error: unknown field "spec.template.spec.containers[1].value", unknown field "spec.template.spec.containers[2].value"
```