### PR TITLE
fix: update kustomization structure for overlays/gke

### DIFF
--- a/overlays/gke/ip-visit/kustomization.yaml
+++ b/overlays/gke/ip-visit/kustomization.yaml
@@ -2,8 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../ip-visit-application.yaml
-
-patches:
-  - path: patches/counter-patch.yaml
-  - path: patches/sqs-consumer-patch.yaml
+  - patches/counter-patch.yaml
+  - patches/sqs-consumer-patch.yaml

--- a/overlays/gke/kustomization.yaml
+++ b/overlays/gke/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - argocd
   - argo-rollouts
   - shared-infra-application.yaml
+  - ip-visit-application.yaml
   - ip-visit
   - visualization-application.yaml
   - ingress.yaml


### PR DESCRIPTION
- Add ip-visit-application.yaml to resources in overlays/gke/kustomization.yaml
- Fix ip-visit/kustomization.yaml to reference patches directly instead of parent directory