### PR TITLE
Refactor/split ingress per app clean

### DIFF
--- a/overlays/gke/ip-visit/ingress.yaml
+++ b/overlays/gke/ip-visit/ingress.yaml
@@ -22,24 +22,10 @@ spec:
             name: ip-visit-counter
             port:
               number: 80
-      - path: /visualization/api
-        pathType: Prefix
-        backend:
-          service:
-            name: visualization-backend
-            port:
-              number: 80
-      - path: /visualization
-        pathType: Prefix
-        backend:
-          service:
-            name: visualization-frontend
-            port:
-              number: 80
       - path: /health
         pathType: Prefix
         backend:
           service:
             name: ip-visit-counter
-            port: 
+            port:
               number: 80

--- a/overlays/gke/kustomization.yaml
+++ b/overlays/gke/kustomization.yaml
@@ -6,8 +6,8 @@ resources:
   - shared-infra-application.yaml
   - ip-visit-application.yaml
   - ip-visit
+  - visualization
   - visualization-application.yaml
-  - ingress.yaml
   - namespace.yaml
   - certificate.yaml
   - secret.yaml

--- a/overlays/gke/visualization/ingress.yaml
+++ b/overlays/gke/visualization/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: playground-metalbear-dev-visualization-ingress
+  namespace: visualization
+  annotations:
+    networking.gke.io/managed-certificates: playground-metalbear-dev-cert
+    kubernetes.io/ingress.class: "gce"
+    ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /visualization/api
+        pathType: Prefix
+        backend:
+          service:
+            name: visualization-backend
+            port:
+              number: 80
+      - path: /visualization
+        pathType: Prefix
+        backend:
+          service:
+            name: visualization-frontend
+            port:
+              number: 80

--- a/overlays/gke/visualization/kustomization.yaml
+++ b/overlays/gke/visualization/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - patches/counter-patch.yaml
-  - patches/sqs-consumer-patch.yaml
+  - ../../manifests/visualization
   - ingress.yaml

--- a/overlays/gke/visualization/kustomization.yaml
+++ b/overlays/gke/visualization/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../manifests/visualization
+  - ../../../manifests/visualization
   - ingress.yaml


### PR DESCRIPTION
## Summary
Split the single ingress into per-app ingresses to comply with Kubernetes constraint that Ingress can only route to Services in the same namespace.

## Changes
Create overlays/gke/ip-visit/ingress.yaml for ip-visit-counter namespace
Routes / (defaultBackend), /count, /health
Create overlays/gke/visualization/ingress.yaml for visualization namespace
Routes /visualization and /visualization/api with rewrite annotation
Create overlays/gke/visualization/kustomization.yaml
Update overlays/gke/ip-visit/kustomization.yaml to include ingress
Update overlays/gke/kustomization.yaml to use visualization overlay
Remove overlays/gke/ingress.yaml (replaced by per-app ingresses)