### PR TITLE
fix: allow HTTPRoutes from all namespaces in Gateway

### DIFF
--- a/overlays/gke/gateway.yaml
+++ b/overlays/gke/gateway.yaml
@@ -15,5 +15,9 @@ spec:
       protocol: HTTPS
       port: 443
       hostname: playground.metalbear.dev
+      allowedRoutes:
+        namespaces:
+          from: All
+          # Allow HTTPRoutes from any namespace (ip-visit-counter, visualization, etc.)
       # TLS termination is handled via the pre-shared-cert annotation above
       # When using pre-shared-certs annotation, do not include tls.certificateRefs


### PR DESCRIPTION
Add allowedRoutes.namespaces.from: All to Gateway listener to enable cross-namespace routing. HTTPRoutes in ip-visit-counter and visualization namespaces need to attach to the shared Gateway.

Without this, Gateway defaults to 'Same' which only allows routes from the same namespace as the Gateway (argocd namespace).