### PR TITLE
fix: add TLS section to Gateway for HTTPS listener

### DIFF
--- a/overlays/gke/gateway.yaml
+++ b/overlays/gke/gateway.yaml
@@ -19,5 +19,8 @@ spec:
         namespaces:
           from: All
           # Allow HTTPRoutes from any namespace (ip-visit-counter, visualization, etc.)
-      # TLS termination is handled via the pre-shared-cert annotation above
-      # When using pre-shared-certs annotation, do not include tls.certificateRefs
+      tls:
+        mode: Terminate
+        # Certificate is specified via the pre-shared-certs annotation above
+        # The annotation networking.gke.io/pre-shared-certs references the SSL certificate
+        # No certificateRefs needed when using pre-shared-certs annotation


### PR DESCRIPTION
GKE Gateway API requires tls section for HTTPS protocol listeners. Certificate is provided via pre-shared-certs annotation.

Fixes error: GWCER106: no certificates specified for protocol HTTPS