### PR TITLE
Fix/gateway httproute and argocd sync

### DIFF
--- a/overlays/gke/ip-visit/httproute.yaml
+++ b/overlays/gke/ip-visit/httproute.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   parentRefs:
     - name: playground-gateway
-      # Gateway namespace defaults to same as HTTPRoute if not specified
+      namespace: argocd
+      # Gateway is in argocd namespace, must explicitly specify for cross-namespace reference
   rules:
     # Default route (/) -> frontend
     - matches:

--- a/overlays/gke/ip-visit/kustomization.yaml
+++ b/overlays/gke/ip-visit/kustomization.yaml
@@ -2,6 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - patches/counter-patch.yaml
-  - patches/sqs-consumer-patch.yaml
   - httproute.yaml

--- a/overlays/gke/visualization/httproute.yaml
+++ b/overlays/gke/visualization/httproute.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   parentRefs:
     - name: playground-gateway
-      # Gateway namespace defaults to same as HTTPRoute if not specified
+      namespace: argocd
+      # Gateway is in argocd namespace, must explicitly specify for cross-namespace reference
   rules:
     # /visualization/api -> backend
     - matches:


### PR DESCRIPTION
Summary
Fixes two issues blocking Gateway API routing and ArgoCD sync:
HTTPRoutes not attaching to Gateway (missing namespace in parentRefs)
ArgoCD sync validation errors (patch files incorrectly included as resources)
Changes
1. Fix HTTPRoute namespace references
Files: overlays/gke/ip-visit/httproute.yaml, overlays/gke/visualization/httproute.yaml
Change: Add namespace: argocd to parentRefs in both HTTPRoutes
Reason: Gateway is in argocd namespace; HTTPRoutes must reference it explicitly for cross-namespace attachment
2. Fix ArgoCD sync errors
File: overlays/gke/ip-visit/kustomization.yaml
Change: Remove patches/counter-patch.yaml and patches/sqs-consumer-patch.yaml from resources:
Reason: These are Application resources, not valid Kustomize resources, causing validation errors during sync