### PR TITLE
fix: remove BackendConfig annotation from visualization-frontend Service

### DIFF
--- a/manifests/visualization/base/frontend/svc.yaml
+++ b/manifests/visualization/base/frontend/svc.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: visualization-frontend
-  annotations:
-    cloud.google.com/backend-config: '{"default":"visualization-frontend-backendconfig"}'
 spec:
   selector:
     app: visualization-frontend


### PR DESCRIPTION
Remove cloud.google.com/backend-config annotation which is Ingress-specific and not supported by Gateway API. This annotation causes Gateway translation errors when the GKE Gateway controller processes Services referenced by HTTPRoutes.

Gateway API handles health checks through standard Kubernetes mechanisms (Service endpoints, Pod readiness probes), so the BackendConfig annotation is not needed and causes validation failures.

Documentation sources:
- GKE Gateway API: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/gateway-api
- Gateway API differences from Ingress: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/gateway-api#differences-from-ingress
- Migrating from Ingress to Gateway API: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/migrating-to-gateway-api

Fixes Gateway sync error:
  failed to translate Gateway: Service has unsupported BackendConfig annotation(s)