### PR TITLE
fix: add named port to ip-visit-frontend service for GKE Gateway API

### DIFF
--- a/manifests/ip-visit/base/app/frontend/svc.yaml
+++ b/manifests/ip-visit/base/app/frontend/svc.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 3000
+  - name: http
+    port: 3000
     protocol: TCP
     targetPort: 3000
   selector:

--- a/manifests/ip-visit/secret.yaml
+++ b/manifests/ip-visit/secret.yaml
@@ -3,6 +3,6 @@ kind: Secret
 metadata:
   name: aws-credentials
 type: Opaque
-data:
-  AWS_ACCESS_KEY_ID: PUT
-  AWS_SECRET_ACCESS_KEY: HERE
+stringData:
+  AWS_ACCESS_KEY_ID: "REPLACE_WITH_ACTUAL_KEY"
+  AWS_SECRET_ACCESS_KEY: "REPLACE_WITH_ACTUAL_SECRET"

--- a/overlays/gke/ip-visit-application.yaml
+++ b/overlays/gke/ip-visit-application.yaml
@@ -20,3 +20,9 @@ spec:
       prune: true
       selfHeal: true
       allowEmpty: false
+  ignoreDifferences:
+    - group: ""
+      kind: Secret
+      name: aws-credentials
+      jsonPointers:
+        - /data


### PR DESCRIPTION
Add 'http' port name to ip-visit-frontend service to fix 502 Bad Gateway errors. GKE Gateway API requires named ports for proper backend service configuration in the Google Cloud Load Balancer.