### PR TITLE
Fix Kafka crash and consumer connectivity issues

### DIFF
--- a/manifests/ip-visit/base/infra/kafka/statefulset.yaml
+++ b/manifests/ip-visit/base/infra/kafka/statefulset.yaml
@@ -15,6 +15,13 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
+      initContainers:
+        - name: cleanup-lost-found
+          image: busybox:latest
+          command: ['sh', '-c', 'rm -rf /tmp/kraft-combined-logs/lost+found || true']
+          volumeMounts:
+            - name: data
+              mountPath: /tmp/kraft-combined-logs
       containers:
         - name: kafka
           image: apache/kafka:4.1.1
@@ -38,7 +45,7 @@ spec:
             - name: KAFKA_LISTENERS
               value: "PLAINTEXT://:9092,CONTROLLER://:9093"
             - name: KAFKA_ADVERTISED_LISTENERS
-              value: "PLAINTEXT://$(POD_NAME).kafka.ip-visit-counter.svc.cluster.local:9092"
+              value: "PLAINTEXT://kafka.ip-visit-counter.svc.cluster.local:9092"
             - name: KAFKA_CONTROLLER_LISTENER_NAMES
               value: "CONTROLLER"
             - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP


### PR DESCRIPTION
- Add init container to remove lost+found directory that causes Kafka to crash
- Update KAFKA_ADVERTISED_LISTENERS to use service name instead of pod name to match consumer connection address