### PR TITLE
Add mirrord CI demo infrastructure

### DIFF
--- a/.github/workflows/ci-demo-mirrord-vs-baseline.yml
+++ b/.github/workflows/ci-demo-mirrord-vs-baseline.yml
@@ -1,0 +1,200 @@
+name: CI Demo - mirrord vs Baseline
+
+on:
+  push:
+    branches:
+      - demo/ci-mirrord
+  workflow_dispatch:
+
+concurrency:
+  group: ci-demo-mirrord-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  baseline-kind:
+    name: Baseline (kind - Slow)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install kind, kubectl, jq
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/kubectl
+          
+          sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Create kind cluster
+        run: |
+          cat <<EOF | kind create cluster --config=- --name ci-demo-${{ github.sha }}
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+          - role: control-plane
+            extraPortMappings:
+            - containerPort: 30080
+              hostPort: 30080
+              protocol: TCP
+          EOF
+          
+          kubectl cluster-info
+
+      - name: Build Docker images
+        run: |
+          export IMAGE_TAG="ci-demo-${{ github.sha }}"
+          
+          # Build ip-visit-counter
+          docker build -t ip-visit-counter:${IMAGE_TAG} -f apps/ip-visit/ip-visit-counter/Dockerfile .
+          
+          # Build ip-info
+          docker build -t ip-info:${IMAGE_TAG} -f apps/ip-visit/ip-info/Dockerfile .
+          
+          # Build ip-info-grpc
+          docker build -t ip-info-grpc:${IMAGE_TAG} -f apps/ip-visit/ip-info-grpc/Dockerfile .
+          
+          # Note: Redis and Kafka use pre-built images from registry
+
+      - name: Load images into kind
+        run: |
+          export IMAGE_TAG="ci-demo-${{ github.sha }}"
+          export CLUSTER_NAME="ci-demo-${{ github.sha }}"
+          
+          kind load docker-image ip-visit-counter:${IMAGE_TAG} --name ${CLUSTER_NAME}
+          kind load docker-image ip-info:${IMAGE_TAG} --name ${CLUSTER_NAME}
+          kind load docker-image ip-info-grpc:${IMAGE_TAG} --name ${CLUSTER_NAME}
+
+      - name: Deploy Redis
+        run: |
+          kubectl apply -k manifests/ip-visit/base/infra/redis
+          kubectl rollout status deployment/redis-main --namespace=ip-visit-counter --timeout=5m
+
+      - name: Deploy Kafka
+        run: |
+          kubectl apply -k manifests/ip-visit/base/infra/kafka
+          kubectl rollout status statefulset/kafka --namespace=ip-visit-counter --timeout=10m
+          # Kafka may need extra time to initialize
+          sleep 10
+
+      - name: Deploy ip-info
+        run: |
+          kubectl apply -k manifests/ip-visit/base/app/ip-info
+          kubectl set image deployment/ip-info main=ip-info:ci-demo-${{ github.sha }} --namespace=ip-visit-counter
+          kubectl rollout status deployment/ip-info --namespace=ip-visit-counter --timeout=5m
+
+      - name: Deploy ip-info-grpc
+        run: |
+          kubectl apply -k manifests/ip-visit/base/app/ip-info-grpc
+          kubectl set image deployment/ip-info-grpc main=ip-info-grpc:ci-demo-${{ github.sha }} --namespace=ip-visit-counter
+          kubectl rollout status deployment/ip-info-grpc --namespace=ip-visit-counter --timeout=5m
+
+      - name: Deploy ip-visit-counter
+        run: |
+          # Apply kind overlay (includes patches for imagePullPolicy and NodePort)
+          kubectl apply -k overlays/kind
+          
+          # Set image tag
+          kubectl set image deployment/ip-visit-counter main=ip-visit-counter:ci-demo-${{ github.sha }} --namespace=ip-visit-counter
+          
+          # Wait for rollout
+          kubectl rollout status deployment/ip-visit-counter --namespace=ip-visit-counter --timeout=5m
+
+      - name: Verify service is accessible
+        run: |
+          kubectl get svc ip-visit-counter --namespace=ip-visit-counter
+          # Wait a moment for service to be ready
+          sleep 5
+
+      - name: Run E2E test
+        env:
+          PLAYGROUND_URL: http://localhost:30080
+          DEMO_TENANT: mirrord-ci-demo
+        run: |
+          chmod +x apps/ip-visit/ip-visit-counter/ci/demo_e2e.sh
+          ./apps/ip-visit/ip-visit-counter/ci/demo_e2e.sh
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: baseline-logs
+          path: |
+            /tmp/kind-*.log
+
+      - name: Delete kind cluster
+        if: always()
+        run: |
+          kind delete cluster --name ci-demo-${{ github.sha }} || true
+
+  mirrord-ci:
+    name: mirrord CI (GKE - Fast)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install jq
+        run: |
+          sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG_BASE64 }}" | base64 -d > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
+          kubectl get ns ip-visit-counter >/dev/null
+
+      - name: Install mirrord
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/metalbear-co/mirrord/main/scripts/install.sh | bash
+          mirrord --version
+          # Verify version >= 3.181.0
+
+      - name: Start mirrord CI
+        env:
+          MIRRORD_CI_API_KEY: ${{ secrets.MIRRORD_CI_API_KEY }}
+        run: |
+          mirrord ci start --config-file .mirrord/mirrord-ci.json -- \
+            go run apps/ip-visit/ip-visit-counter/main.go
+          
+          # Give the local server a moment to boot
+          sleep 10
+
+      - name: Run E2E test
+        env:
+          PLAYGROUND_URL: https://playground.metalbear.dev
+          DEMO_TENANT: mirrord-ci-demo
+        run: |
+          chmod +x apps/ip-visit/ip-visit-counter/ci/demo_e2e.sh
+          ./apps/ip-visit/ip-visit-counter/ci/demo_e2e.sh
+
+      - name: Stop mirrord CI session
+        if: always()
+        run: |
+          mirrord ci stop || true
+
+      - name: Upload mirrord logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mirrord-logs
+          path: /tmp/mirrord

--- a/.mirrord/mirrord-ci.json
+++ b/.mirrord/mirrord-ci.json
@@ -1,0 +1,25 @@
+{
+  "target": {
+    "namespace": "ip-visit-counter",
+    "path": {
+      "deployment": "ip-visit-counter"
+    }
+  },
+  "ci": {
+    "output_dir": "/tmp/mirrord"
+  },
+  "feature": {
+    "network": {
+      "incoming": {
+        "mode": "steal",
+        "http_filter": {
+          "header_filter": "X-PG-Tenant: mirrord-ci-demo"
+        }
+      },
+      "outgoing": true
+    },
+    "fs": {
+      "mode": "read"
+    }
+  }
+}

--- a/apps/ip-visit/ip-visit-counter/ci/demo_e2e.sh
+++ b/apps/ip-visit/ip-visit-counter/ci/demo_e2e.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PLAYGROUND_URL:?Need PLAYGROUND_URL (e.g. http://localhost:30080 or https://playground.metalbear.dev)}"
+: "${DEMO_TENANT:?Need DEMO_TENANT (e.g. mirrord-ci-demo)}"
+
+echo "Hitting ${PLAYGROUND_URL}/count with tenant=${DEMO_TENANT}"
+
+resp="$(curl -sS -H "X-PG-Tenant: ${DEMO_TENANT}" "${PLAYGROUND_URL}/count")"
+echo "$resp" | jq .
+
+# Assert: unique_ips exists and is a number
+echo "$resp" | jq -e '.unique_ips | type == "number"' >/dev/null || {
+	echo "❌ ERROR: unique_ips field missing or not a number"
+	exit 1
+}
+
+# Assert: demo_marker exists and equals "mirrord-ci-demo"
+echo "$resp" | jq -e '.demo_marker == "mirrord-ci-demo"' >/dev/null || {
+	echo "❌ ERROR: demo_marker missing or incorrect"
+	exit 1
+}
+
+echo "✅ demo_e2e passed"

--- a/overlays/kind/kustomization.yaml
+++ b/overlays/kind/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ip-visit-counter
+
+resources:
+  - ../../manifests/ip-visit
+
+patches:
+  - path: patches/image-pull-policy.yaml
+    target:
+      kind: Deployment
+  - path: patches/nodeport-service.yaml
+    target:
+      kind: Service
+      name: ip-visit-counter

--- a/overlays/kind/patches/image-pull-policy.yaml
+++ b/overlays/kind/patches/image-pull-policy.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: placeholder
+spec:
+  template:
+    spec:
+      containers:
+      - name: main
+        imagePullPolicy: Never

--- a/overlays/kind/patches/nodeport-service.yaml
+++ b/overlays/kind/patches/nodeport-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ip-visit-counter
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 80
+    nodePort: 30080
+    protocol: TCP


### PR DESCRIPTION
- Add E2E test script for validating unique_ips and demo_marker fields
- Add mirrord CI configuration targeting ip-visit-counter deployment
- Add kind overlay with patches for imagePullPolicy and NodePort service
- Add GitHub Actions workflow comparing baseline (kind) vs mirrord CI

This infrastructure can be safely merged to main as the workflow only triggers on demo/ci-mirrord branch. ArgoCD will ignore the kind overlay as it only watches explicitly configured paths.