### PR TITLE
Fix CI workflow issues: GKE auth plugin and Docker build

### DIFF
--- a/.github/workflows/ci-demo-mirrord-vs-baseline.yml
+++ b/.github/workflows/ci-demo-mirrord-vs-baseline.yml
@@ -156,11 +156,25 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y jq
 
+      - name: Install kubectl and gke-gcloud-auth-plugin
+        run: |
+          # Install kubectl
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/kubectl
+          
+          # Install gke-gcloud-auth-plugin
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl-gke-gcloud-auth-plugin"
+          chmod +x kubectl-gke-gcloud-auth-plugin
+          sudo mv kubectl-gke-gcloud-auth-plugin /usr/local/bin/kubectl-gke-gcloud-auth-plugin
+
       - name: Configure kubeconfig
         run: |
           mkdir -p $HOME/.kube
           echo "${{ secrets.KUBECONFIG_BASE64 }}" | base64 -d > $HOME/.kube/config
           chmod 600 $HOME/.kube/config
+          # Update auth plugin path in kubeconfig to use installed plugin
+          sed -i 's|/opt/homebrew/share/google-cloud-sdk/bin/gke-gcloud-auth-plugin|/usr/local/bin/kubectl-gke-gcloud-auth-plugin|g' $HOME/.kube/config
           kubectl get ns ip-visit-counter >/dev/null
 
       - name: Install mirrord

--- a/apps/ip-visit/ip-info/Dockerfile
+++ b/apps/ip-visit/ip-info/Dockerfile
@@ -1,11 +1,12 @@
 FROM --platform=$BUILDPLATFORM golang:1.23-alpine as build-env
 
 WORKDIR /app
-COPY go.mod ./
-COPY go.sum ./
+COPY apps/ip-visit/ip-info/go.mod ./
+COPY apps/ip-visit/ip-info/go.sum ./
 RUN go mod download
-COPY *.go ./
+COPY apps/ip-visit/ip-info/*.go ./
 
+ARG TARGETARCH
 RUN GOARCH=$TARGETARCH go build -o /main
 
 FROM gcr.io/distroless/static-debian11


### PR DESCRIPTION
- Install kubectl and gke-gcloud-auth-plugin on Ubuntu runner
- Update kubeconfig auth plugin path from macOS to Linux
- Fix ip-info Dockerfile to copy from correct paths

These fixes are needed for the CI workflow to work properly.