### PR TITLE
Fix ip-info Dockerfile: remove duplicate COPY commands from PR #71

### DIFF
--- a/apps/ip-visit/ip-info/Dockerfile
+++ b/apps/ip-visit/ip-info/Dockerfile
@@ -1,10 +1,10 @@
 FROM --platform=$BUILDPLATFORM golang:1.23-alpine as build-env
 
 WORKDIR /app
-COPY apps/ip-visit/ip-info/go.mod ./
-COPY apps/ip-visit/ip-info/go.sum ./
+COPY go.mod ./
+COPY go.sum ./
 RUN go mod download
-COPY apps/ip-visit/ip-info/*.go ./
+COPY *.go ./
 
 ARG TARGETARCH
 RUN GOARCH=$TARGETARCH go build -o /main


### PR DESCRIPTION
Revert breaking change that added absolute paths in COPY commands. The build context is apps/ip-visit/ip-info/, so paths must be relative. This restores the working Dockerfile configuration.