### PR TITLE
Remove unnecessary sleep command from mirrord CI workflow

### DIFF
--- a/.github/workflows/ci-demo-mirrord-vs-baseline.yml
+++ b/.github/workflows/ci-demo-mirrord-vs-baseline.yml
@@ -181,9 +181,6 @@ jobs:
         run: |
           mirrord ci start --config-file .mirrord/mirrord-ci.json -- \
             go run apps/ip-visit/ip-visit-counter/main.go
-          
-          # Give the local server a moment to boot
-          sleep 10
 
       - name: Run E2E test
         env:


### PR DESCRIPTION
mirrord ci start runs the process in the background automatically, so no sleep is needed. The process is ready immediately after the command returns.