### PR TITLE
fix(shop): remove duplicate basePath from frontend Link hrefs

### DIFF
--- a/apps/shop/metal-mart-frontend/src/app/cart/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/cart/page.tsx
@@ -25,11 +25,11 @@ export default function CartPage() {
       if (existing) existing.quantity++;
       else items.push({ productId: id, quantity: 1 });
       localStorage.setItem("metal-mart-cart", JSON.stringify(items));
-      window.history.replaceState({}, "", basePath ? `${basePath}/cart` : "/cart");
+      window.history.replaceState({}, "", `${basePath}/cart`);
     }
     Promise.all(
       items.map(async (i) => {
-        const r = await fetch(basePath ? `${basePath}/api/products/${i.productId}` : `/api/products/${i.productId}`);
+        const r = await fetch(`${basePath}/api/products/${i.productId}`);
         const p = await r.json();
         return { ...i, product: p };
       })
@@ -57,14 +57,14 @@ export default function CartPage() {
   return (
     <div className="flex min-h-screen flex-col">
       <header className="border-b border-slate-700 px-6 py-4">
-        <Link href={basePath || "/"} className="text-xl font-bold text-amber-400">
+        <Link href="/" className="text-xl font-bold text-amber-400">
           MetalMart
         </Link>
         <div className="mt-2 flex gap-4">
-          <Link href={basePath ? `${basePath}/products` : "/products"} className="text-slate-300 hover:text-white">
+          <Link href="/products" className="text-slate-300 hover:text-white">
             Products
           </Link>
-          <Link href={basePath ? `${basePath}/cart` : "/cart"} className="text-slate-300 hover:text-white">
+          <Link href="/cart" className="text-slate-300 hover:text-white">
             Cart
           </Link>
         </div>
@@ -100,7 +100,7 @@ export default function CartPage() {
             </ul>
             <p className="mt-6 text-xl font-semibold">Total: ${(totalCents / 100).toFixed(2)}</p>
             <Link
-              href={basePath ? `${basePath}/checkout` : "/checkout"}
+              href="/checkout"
               className="mt-4 inline-block rounded-lg bg-amber-500 px-6 py-2 font-medium text-slate-900 hover:bg-amber-400"
             >
               Checkout

--- a/apps/shop/metal-mart-frontend/src/app/checkout/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/checkout/page.tsx
@@ -22,7 +22,7 @@ export default function CheckoutPage() {
     const items: { productId: number; quantity: number }[] = raw ? JSON.parse(raw) : [];
     Promise.all(
       items.map(async (i) => {
-        const r = await fetch(basePath ? `${basePath}/api/products/${i.productId}` : `/api/products/${i.productId}`);
+        const r = await fetch(`${basePath}/api/products/${i.productId}`);
         const p = await r.json();
         return { ...i, product: p };
       })
@@ -35,7 +35,7 @@ export default function CheckoutPage() {
   const handleSubmit = async () => {
     setSubmitting(true);
     try {
-      const r = await fetch(basePath ? `${basePath}/api/orders` : "/api/orders", {
+      const r = await fetch(`${basePath}/api/orders`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ items: orderItems, total_cents: totalCents }),
@@ -60,7 +60,7 @@ export default function CheckoutPage() {
     return (
       <div className="flex min-h-screen flex-col">
         <header className="border-b border-slate-700 px-6 py-4">
-          <Link href={basePath || "/"} className="text-xl font-bold text-amber-400">
+          <Link href="/" className="text-xl font-bold text-amber-400">
             MetalMart
           </Link>
         </header>
@@ -68,7 +68,7 @@ export default function CheckoutPage() {
           <h1 className="text-2xl font-bold text-green-400">Order placed!</h1>
           <p className="text-slate-400">Order ID: {orderId}</p>
           <Link
-            href={basePath ? `${basePath}/orders/${orderId}` : `/orders/${orderId}`}
+            href={`/orders/${orderId}`}
             className="rounded-lg bg-amber-500 px-6 py-2 font-medium text-slate-900 hover:bg-amber-400"
           >
             Track order
@@ -82,7 +82,7 @@ export default function CheckoutPage() {
     return (
       <div className="flex min-h-screen flex-col">
         <header className="border-b border-slate-700 px-6 py-4">
-          <Link href={basePath || "/"} className="text-xl font-bold text-amber-400">
+          <Link href="/" className="text-xl font-bold text-amber-400">
             MetalMart
           </Link>
         </header>
@@ -96,7 +96,7 @@ export default function CheckoutPage() {
   return (
     <div className="flex min-h-screen flex-col">
       <header className="border-b border-slate-700 px-6 py-4">
-        <Link href={basePath || "/"} className="text-xl font-bold text-amber-400">
+        <Link href="/" className="text-xl font-bold text-amber-400">
           MetalMart
         </Link>
       </header>

--- a/apps/shop/metal-mart-frontend/src/app/orders/[id]/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/orders/[id]/page.tsx
@@ -17,8 +17,8 @@ export default function OrderPage() {
     if (!id) return;
     const load = async () => {
       const [orderRes, deliveryRes] = await Promise.all([
-        fetch(basePath ? `${basePath}/api/orders/${id}` : `/api/orders/${id}`),
-        fetch(basePath ? `${basePath}/api/deliveries/order/${id}` : `/api/deliveries/order/${id}`),
+        fetch(`${basePath}/api/orders/${id}`),
+        fetch(`${basePath}/api/deliveries/order/${id}`),
       ]);
       const ord = await orderRes.json();
       const del = await deliveryRes.json();
@@ -34,7 +34,7 @@ export default function OrderPage() {
   return (
     <div className="flex min-h-screen flex-col">
       <header className="border-b border-slate-700 px-6 py-4">
-        <Link href={basePath || "/"} className="text-xl font-bold text-amber-400">
+        <Link href="/" className="text-xl font-bold text-amber-400">
           MetalMart
         </Link>
       </header>

--- a/apps/shop/metal-mart-frontend/src/app/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/page.tsx
@@ -1,12 +1,10 @@
 import Link from "next/link";
 
-const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
-
 export default function Home() {
   return (
     <div className="flex min-h-screen flex-col">
       <header className="border-b border-slate-700 px-6 py-4">
-        <Link href={basePath ? `${basePath}/products` : "/products"} className="text-xl font-bold text-amber-400">
+        <Link href="/products" className="text-xl font-bold text-amber-400">
           MetalMart
         </Link>
         <p className="text-sm text-slate-400">Official MetalBear Swag</p>
@@ -15,7 +13,7 @@ export default function Home() {
         <h1 className="text-3xl font-bold text-slate-100">Welcome to MetalMart</h1>
         <p className="text-slate-400">Gear up with official MetalBear merchandise</p>
         <Link
-          href={basePath ? `${basePath}/products` : "/products"}
+          href="/products"
           className="rounded-lg bg-amber-500 px-6 py-3 font-medium text-slate-900 hover:bg-amber-400"
         >
           Browse Catalogue

--- a/apps/shop/metal-mart-frontend/src/app/products/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/page.tsx
@@ -19,7 +19,7 @@ export default function ProductsPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch(basePath ? `${basePath}/api/products` : "/api/products")
+    fetch(`${basePath}/api/products`)
       .then((r) => r.json())
       .then(setProducts)
       .catch((e) => setError(e.message))
@@ -32,14 +32,14 @@ export default function ProductsPage() {
   return (
     <div className="flex min-h-screen flex-col">
       <header className="border-b border-slate-700 px-6 py-4">
-        <Link href={basePath || "/"} className="text-xl font-bold text-amber-400">
+        <Link href="/" className="text-xl font-bold text-amber-400">
           MetalMart
         </Link>
         <div className="mt-2 flex gap-4">
-          <Link href={basePath ? `${basePath}/products` : "/products"} className="text-slate-300 hover:text-white">
+          <Link href="/products" className="text-slate-300 hover:text-white">
             Products
           </Link>
-          <Link href={basePath ? `${basePath}/cart` : "/cart"} className="text-slate-300 hover:text-white">
+          <Link href="/cart" className="text-slate-300 hover:text-white">
             Cart
           </Link>
         </div>
@@ -57,7 +57,7 @@ export default function ProductsPage() {
               <p className="mt-2 text-amber-400">${(p.price_cents / 100).toFixed(2)}</p>
               <p className="text-xs text-slate-500">In stock: {p.stock}</p>
               <Link
-                href={basePath ? `${basePath}/cart?add=${p.id}` : `/cart?add=${p.id}`}
+                href={`/cart?add=${p.id}`}
                 className="mt-3 inline-block rounded bg-amber-500 px-3 py-1 text-sm font-medium text-slate-900 hover:bg-amber-400"
               >
                 Add to cart


### PR DESCRIPTION
Next.js automatically prepends basePath to Link hrefs when configured in next.config.ts. The manual basePath addition was causing double paths like /shop/shop/products.