### PR TITLE
fix(shop): add GKE HealthCheckPolicy for metal-mart-frontend

### DIFF
--- a/overlays/gke/shop/healthcheckpolicy.yaml
+++ b/overlays/gke/shop/healthcheckpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: metal-mart-frontend-healthcheck
+  namespace: shop
+spec:
+  default:
+    checkIntervalSec: 10
+    timeoutSec: 5
+    healthyThreshold: 1
+    unhealthyThreshold: 3
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /shop
+        port: 3000
+  targetRef:
+    group: ""
+    kind: Service
+    name: metal-mart-frontend

--- a/overlays/gke/shop/kustomization.yaml
+++ b/overlays/gke/shop/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - httproute.yaml
+  - healthcheckpolicy.yaml


### PR DESCRIPTION
Fixes 'no healthy upstream' when accessing /shop via the gateway by telling the load balancer to probe GET /shop on port 3000.