### PR TITLE
feat(infra): add shared infra namespace with Redis, Kafka, Postgres (…

### DIFF
--- a/manifests/infrastructure/kafka/kustomization.yaml
+++ b/manifests/infrastructure/kafka/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespaces.yaml
-  - shared
+  - statefulset.yaml
+  - svc.yaml

--- a/manifests/infrastructure/kafka/statefulset.yaml
+++ b/manifests/infrastructure/kafka/statefulset.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka
+spec:
+  serviceName: kafka
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      securityContext:
+        fsGroup: 1000
+      initContainers:
+        - name: cleanup-lost-found
+          image: busybox:latest
+          command: ['sh', '-c', 'rm -rf /tmp/kraft-combined-logs/lost+found || true']
+          volumeMounts:
+            - name: data
+              mountPath: /tmp/kraft-combined-logs
+      containers:
+        - name: kafka
+          image: apache/kafka:4.1.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9092
+              name: plaintext
+              protocol: TCP
+            - containerPort: 9093
+              name: controller
+              protocol: TCP
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_PROCESS_ROLES
+              value: "broker,controller"
+            - name: KAFKA_LISTENERS
+              value: "PLAINTEXT://:9092,CONTROLLER://:9093"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "PLAINTEXT://kafka.infra.svc.cluster.local:9092"
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: "1@kafka-0.kafka.infra.svc.cluster.local:9093"
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "true"
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_LOG_DIRS
+              value: "/tmp/kraft-combined-logs"
+            - name: CLUSTER_ID
+              value: "MkU3OEVBNTcwNTJENDM2Qk"
+          volumeMounts:
+            - name: data
+              mountPath: /tmp/kraft-combined-logs
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/manifests/infrastructure/kafka/svc.yaml
+++ b/manifests/infrastructure/kafka/svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  labels:
+    app: kafka
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 9092
+      name: plaintext
+      protocol: TCP
+      targetPort: 9092
+  selector:
+    app: kafka

--- a/manifests/infrastructure/namespaces.yaml
+++ b/manifests/infrastructure/namespaces.yaml
@@ -2,6 +2,11 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: infra
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: ip-visit-counter
 ---
 apiVersion: v1

--- a/manifests/infrastructure/postgres/configmap.yaml
+++ b/manifests/infrastructure/postgres/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init
+data:
+  init-databases.sh: |
+    #!/bin/bash
+    set -e
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+        CREATE DATABASE inventory;
+        CREATE DATABASE orders;
+        CREATE DATABASE deliveries;
+    EOSQL

--- a/manifests/infrastructure/postgres/deployment.yaml
+++ b/manifests/infrastructure/postgres/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: init-scripts
+          configMap:
+            name: postgres-init
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+type: Opaque
+stringData:
+  password: postgres

--- a/manifests/infrastructure/postgres/kustomization.yaml
+++ b/manifests/infrastructure/postgres/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespaces.yaml
-  - shared
+  - configmap.yaml
+  - deployment.yaml
+  - svc.yaml

--- a/manifests/infrastructure/postgres/svc.yaml
+++ b/manifests/infrastructure/postgres/svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+      name: postgres
+  selector:
+    app: postgres

--- a/manifests/infrastructure/redis/deployment.yaml
+++ b/manifests/infrastructure/redis/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-main
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - image: registry.k8s.io/redis
+        imagePullPolicy: Always
+        name: main
+        ports:
+        - containerPort: 6379
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/manifests/infrastructure/redis/kustomization.yaml
+++ b/manifests/infrastructure/redis/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespaces.yaml
-  - shared
+  - deployment.yaml
+  - svc.yaml

--- a/manifests/infrastructure/redis/svc.yaml
+++ b/manifests/infrastructure/redis/svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-main
+  labels:
+    app: redis
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: redis

--- a/manifests/infrastructure/shared/kustomization.yaml
+++ b/manifests/infrastructure/shared/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: infra
 resources:
-  - namespaces.yaml
-  - shared
+  - ../redis
+  - ../kafka
+  - ../postgres

--- a/overlays/gke/shared-infra-application.yaml
+++ b/overlays/gke/shared-infra-application.yaml
@@ -8,7 +8,7 @@ metadata:
     - resources-finalizer.argoproj.io
 spec:
   destination:
-    namespace: default
+    namespace: infra
     server: https://kubernetes.default.svc
   project: default
   source:


### PR DESCRIPTION
…PR 1/3)

- Add infra namespace to manifests/infrastructure/namespaces.yaml
- Add Redis, Kafka, Postgres under manifests/infrastructure/ (shared kustomization)
- Kafka configured for infra: kafka.infra.svc.cluster.local
- Point Argo shared-infra Application destination to namespace: infra

No changes to ip-visit or shop; they keep using in-namespace infra. Prep for PR 2 (point apps at infra) and PR 3 (remove per-app infra).