### PR TITLE
docs: add agentic context git pattern (AGENTS.md + docs/)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Agent context
+
+Use this file and `docs/` for project context when working in this repo.
+
+## Entry points
+
+- **Project overview, layout, deployment:** [docs/AI_ROOT_CONTEXT.md](docs/AI_ROOT_CONTEXT.md)
+- **Feature planning and migrations:** Other markdown files in [docs/](docs/). Check for `*-END-STATE.md`, `*-MIGRATION.md`, etc.
+- **How we use context in git:** [docs/AGENTIC-CONTEXT-GIT-PATTERN.md](docs/AGENTIC-CONTEXT-GIT-PATTERN.md)
+
+## Conventions
+
+- When starting a feature, look in `docs/` for an existing plan (end-state, migration) and follow it.
+- Commit planning or context docs in the **same branch/PR** as the implementation so git history carries the plan.
+- Prefer minimal, directive context; avoid long prose.
+
+## Build and deploy
+
+- **GKE:** `kubectl apply -k overlays/gke` (or `kustomize build --enable-helm overlays/gke | kubectl apply -f -`). See [docs/AI_ROOT_CONTEXT.md](docs/AI_ROOT_CONTEXT.md) and `overlays/gke/DRY-RUN.md` if present.
+- **Apps:** See `apps/*/README.md` and root [README.md](README.md) for local run, SQS, proto.

--- a/docs/AGENTIC-CONTEXT-GIT-PATTERN.md
+++ b/docs/AGENTIC-CONTEXT-GIT-PATTERN.md
@@ -1,0 +1,61 @@
+# Agentic context + git pattern (proposal)
+
+**Goal:** Commit planning and context markdown files so they live in git, give agents and humans a single source of truth, and survive across sessions and handoffs.
+
+---
+
+## What's out there
+
+- **AGENTS.md** ([agents.md](https://agents.md/)) – Single root file for *project-wide* agent instructions (build, test, conventions). Not for feature-level planning.
+- **.context/** ([Codebase Context Spec](https://github.com/Agentic-Insights/codebase-context-spec)) – Directory with `index.md` (and optional YAML/JSON) for architecture, conventions, design decisions. Tool-agnostic; can nest by area.
+- **docs/** – Generic place for planning/design docs; we use it for `AI_ROOT_CONTEXT.md`, feature end-states, migrations.
+- **Git as memory** – Letta "context repositories," GitHub repo-memory: context files in the repo, versioned with commits so agents (and people) get history and branching.
+
+Common idea: **context and planning as normal files in the repo, committed on the same branch as the work**, so the next session or another agent can open the branch and read the plan.
+
+---
+
+## Our approach
+
+### 1. Use `docs/` for context and planning
+
+- **`docs/AI_ROOT_CONTEXT.md`** – Project overview, layout, deployment. "Start here" for agents and onboarding.
+- **`docs/<FEATURE>-*.md`** or **`docs/<AREA>-*.md`** – Planning, end-state, or migration for a feature/area (e.g. `SHOP-EXPERIENCE-END-STATE.md`, `INFRA-NAMESPACE-MIGRATION.md`).
+- Stay **flat in `docs/`** with descriptive names unless the number of files grows; then consider `docs/planning/` for planning-only.
+
+### 2. When to commit context docs
+
+- **With the work:** Commit the context/planning doc in the **same branch and PR** as the implementation (e.g. first commit: "docs: add SHOP-EXPERIENCE-END-STATE" then implement; or plan + implementation in one PR).
+- Git history then carries "this branch is about X, and here's the plan."
+
+### 3. Entry point for agents
+
+- Root **`AGENTS.md`** points at `docs/AI_ROOT_CONTEXT.md` and `docs/`, and tells agents to check `docs/` for planning before starting a feature.
+
+### 4. What to put in planning docs
+
+- **End-state / vision:** Target UX, schema, APIs.
+- **Migrations / big changes:** Steps, order, rollback.
+- **Decisions:** "We chose X because Y" so future work doesn't reverse it by accident.
+
+Keep them **short and directive**.
+
+---
+
+## Summary
+
+| Decision | Choice |
+|----------|--------|
+| **Where** | `docs/`; optional `docs/planning/` later if needed. |
+| **When** | Commit planning/context docs on the **same branch/PR** as the implementation. |
+| **Entry point** | Root `AGENTS.md` → `docs/AI_ROOT_CONTEXT.md` and `docs/`. |
+| **Naming** | Descriptive: `FEATURE-END-STATE.md`, `AREA-MIGRATION.md`, etc. |
+
+---
+
+## References
+
+- [AGENTS.md](https://agents.md/) – Root-level agent instructions.
+- [Codebase Context Specification](https://github.com/Agentic-Insights/codebase-context-spec) – `.context/` and index.md.
+- [Tweag Agentic Coding Handbook – Project instructions](https://tweag.github.io/agentic-coding-handbook/PRJ_INSTRUCTIONS/).
+- [Letta – Context Repositories (git-based memory)](https://www.letta.com/blog/context-repositories).

--- a/docs/AI_ROOT_CONTEXT.md
+++ b/docs/AI_ROOT_CONTEXT.md
@@ -1,0 +1,90 @@
+# Playground – Full Project Explanation
+
+**Reference this file** (`docs/AI_ROOT_CONTEXT.md`) in new chats or onboarding so the project context is clear without daisy-chaining old transcripts.
+
+---
+
+## What this repo is
+
+**MetalBear Playground** – A monorepo of demo apps and microservices, with Kubernetes manifests and overlays to run them locally (minikube/kind) or on **GKE**. Used to showcase **mirrord** (HTTP filtering, queue splitting, DB branching) and related tooling.
+
+- **Upstream:** `https://github.com/metalbear-co/playground` (remote: `mb`)
+- **Live:** https://playground.metalbear.dev (GKE; gateway routes by path)
+
+---
+
+## Directory layout
+
+| Path | Purpose |
+|------|---------|
+| **`apps/`** | Application source code. One subfolder per "product"; each may have multiple services. |
+| **`manifests/`** | Kubernetes base resources and kustomizations. What gets deployed (per env) lives here. |
+| **`overlays/`** | Environment-specific patches and wiring (GKE, kind, local, localstack). |
+| **`proto/`** | Protobuf definitions (e.g. ipinfo). **`protogen/`** = generated Go. |
+| **`.github/workflows/`** | CI: build and push container images on push to `main`. |
+
+---
+
+## Apps (source: `apps/`)
+
+- **`apps/ip-visit/`** – IP visit counter demo: ip-info, ip-info-grpc, ip-visit-counter, ip-visit-frontend, ip-visit-consumer (Kafka), ip-visit-sqs-consumer. Uses Redis, optional SQS/Kafka.
+- **`apps/shop/`** – **MetalMart** ecommerce demo: metal-mart-frontend (Next.js), inventory-service, order-service, payment-service, delivery-service. Uses Postgres + Kafka (+ Temporal for checkout/delivery workflows). See `apps/shop/README.md`.
+- **`apps/visualization/`** – visualization-frontend + visualization-backend.
+
+Manifests that deploy these live under **`manifests/`** (e.g. `manifests/shop`, `manifests/ip-visit`, `manifests/visualization`).
+
+---
+
+## Overlays (where we deploy *to*)
+
+- **`overlays/gke`** – Production GKE: Argo CD, Gateway API, HTTPRoutes, HealthCheckPolicies, Argo Applications that sync from the repo. Apply with `kubectl apply -k overlays/gke`. See **`overlays/gke/DRY-RUN.md`** for dry-run steps if present.
+- **`overlays/kind`**, **`overlays/local`**, **`overlays/localstack`** – Local/minikube and localstack variants (see root **`README.md`**).
+
+---
+
+## GKE deployment flow
+
+1. **Bootstrap (one-time or when changing platform config):**  
+   `kubectl apply -k overlays/gke`  
+   This applies Argo CD, the Gateway, namespaces, **Argo Applications** (e.g. shop, ip-visit, visualization, shared-infra, temporal), and GKE-specific resources (HTTPRoutes, HealthCheckPolicies, etc.).
+
+2. **App content:**  
+   Argo CD syncs from **`metalbear-co/playground`** **`main`** (or configured branch). Each Application points at a path under **`manifests/`** (e.g. `manifests/shop`). So merging to `main` updates what Argo syncs; the overlay only defines *that* the app exists and how it's exposed (routes, health checks).
+
+3. **Shop on GKE:**  
+   - Namespace: **`shop`**.  
+   - Frontend is exposed at **`https://playground.metalbear.dev/shop`** via the gateway HTTPRoute.  
+   - **HealthCheckPolicy** for `metal-mart-frontend` is required so the GKE load balancer marks the backend healthy. Defined in **`overlays/gke/shop/healthcheckpolicy.yaml`** and included in **`overlays/gke/shop/kustomization.yaml`**.
+
+---
+
+## Shared infrastructure
+
+- **Namespace:** `infra`. Redis, Kafka, Postgres live in **`manifests/infrastructure`** and are deployed by the Argo Application **shared-infra**. Apps (ip-visit, shop) reference them via FQDN (e.g. `redis-main.infra.svc.cluster.local`, `kafka.infra.svc.cluster.local`, `postgres.infra.svc.cluster.local`).
+
+---
+
+## Images and rollouts
+
+- **Builds:** GitHub Actions (`.github/workflows/build-*.yaml`) build and push images on **push to `main`**. Images are tagged e.g. `ghcr.io/metalbear-co/playground-metal-mart-frontend:latest` and `:${{ github.sha }}`.
+- **Deployments** in manifests typically use **`:latest`** with **`imagePullPolicy: Always`**.
+- **Important:** Kubernetes does *not* recreate pods when only the *content* of the image at `:latest` changes; the Deployment spec (same tag) is unchanged, so no rollout. To get a new image after a code push you must either:
+  - **Restart the deployment:** e.g. `kubectl rollout restart deployment/metal-mart-frontend -n shop`, or  
+  - **Change the image spec** (e.g. use image tag by commit SHA or digest in the manifest and have CI/Argo update it so that a new rollout is triggered).
+
+---
+
+## Git remotes
+
+- **`origin`** – Typically your fork (e.g. `karlod-metalbear/playground`). Push feature branches here and open PRs to upstream.
+- **`mb`** – Upstream **metalbear-co/playground**. Merge via PR; Argo on GKE syncs from here (e.g. `targetRevision: HEAD` for `main`).
+
+---
+
+## Quick reference
+
+- **Root README:** general deploy commands, SQS, proto, local/minikube.
+- **`overlays/gke/DRY-RUN.md`** – How to dry-run the GKE overlay before applying (if present).
+- **`apps/shop/README.md`** – MetalMart architecture, mirrord features, local dev, live URL.
+
+When starting a new chat or onboarding, **reference this file** (`docs/AI_ROOT_CONTEXT.md`) so the full project context is available without re-reading previous transcripts.

--- a/docs/INFRA-NAMESPACE-MIGRATION.md
+++ b/docs/INFRA-NAMESPACE-MIGRATION.md
@@ -1,0 +1,167 @@
+# Migration: Shared infra namespace for Redis, Kafka, Postgres
+
+**Goal:** Move Redis, Kafka, and Postgres from app-specific namespaces (ip-visit-counter, shop) into a dedicated **`infra`** namespace and have all apps reference this shared infrastructure.
+
+---
+
+## Current state
+
+| Component | Location | Consumers |
+|-----------|----------|-----------|
+| **Redis** | `manifests/ip-visit/base/infra/redis` → namespace `ip-visit-counter` | ip-visit counter |
+| **Kafka** | `manifests/ip-visit/base/infra/kafka` → `ip-visit-counter` | ip-visit counter, consumer-kafka |
+| **Kafka** | `manifests/shop/base/infra/kafka` → `shop` | shop (order, delivery, etc.) |
+| **Postgres** | `manifests/shop/base/infra/postgres` → `shop` | shop (inventory, order, payment, delivery) |
+
+- **`manifests/infrastructure`** today only defines **namespaces** (ip-visit-counter, shop, visualization) and is deployed by the Argo CD Application **shared-infra** (destination namespace in that app is `default`; only cluster-scoped namespaces are in that kustomization).
+- Apps use short DNS names: `redis-main:6379`, `kafka:9092`, `postgres:5432` (same-namespace resolution).
+
+---
+
+## Target state
+
+| Component | Location | Namespace | Consumers |
+|-----------|----------|-----------|-----------|
+| **Redis** | `manifests/infrastructure/redis/` | `infra` | ip-visit (counter) |
+| **Kafka** | `manifests/infrastructure/kafka/` | `infra` | ip-visit + shop |
+| **Postgres** | `manifests/infrastructure/postgres/` | `infra` | shop |
+
+- **`manifests/infrastructure`** defines the **`infra`** namespace and all shared infra resources (redis, kafka, postgres), with `namespace: infra` so everything lands in `infra`.
+- **shared-infra** Argo Application keeps pointing at `manifests/infrastructure`; we change its **destination namespace** to **`infra`** (for the non-namespace resources).
+- **ip-visit** and **shop** manifests no longer include any `base/infra/*`; their deployments reference infra via FQDN:
+  - `redis-main.infra.svc.cluster.local:6379`
+  - `kafka.infra.svc.cluster.local:9092`
+  - `postgres.infra.svc.cluster.local:5432`
+
+---
+
+## Migration steps (checklist)
+
+### Phase 1: Add shared infra resources under `manifests/infrastructure`
+
+1. **Add `infra` namespace**  
+   In `manifests/infrastructure/namespaces.yaml`, add:
+   ```yaml
+   ---
+   apiVersion: v1
+   kind: Namespace
+   metadata:
+     name: infra
+   ```
+
+2. **Create `manifests/infrastructure/redis/`**  
+   - Copy from `manifests/ip-visit/base/infra/redis/` (deployment.yaml, svc.yaml, kustomization.yaml).
+   - No changes to resource names; service stays `redis-main`. Kustomization will apply `namespace: infra` at the top level.
+
+3. **Create `manifests/infrastructure/kafka/`**  
+   - Use one copy (e.g. from `manifests/ip-visit/base/infra/kafka/` or shop) of statefulset + svc + kustomization.
+   - In the Kafka StatefulSet, set:
+     - `KAFKA_ADVERTISED_LISTENERS`: `PLAINTEXT://kafka.infra.svc.cluster.local:9092`
+     - `KAFKA_CONTROLLER_QUORUM_VOTERS`: `1@kafka-0.kafka.infra.svc.cluster.local:9093`
+   - Pick one `CLUSTER_ID` (e.g. keep one of the existing values for simplicity).
+
+4. **Create `manifests/infrastructure/postgres/`**  
+   - Copy from `manifests/shop/base/infra/postgres/` (configmap, deployment, secret, svc, kustomization).
+   - No hostname changes inside Postgres; only the namespace changes.
+
+5. **Update `manifests/infrastructure/kustomization.yaml`**  
+   - Set `namespace: infra` so all resources go to the infra namespace.
+   - Add resources:
+     ```yaml
+     namespace: infra
+     resources:
+       - namespaces.yaml
+       - redis
+       - kafka
+       - postgres
+     ```
+   - Note: `namespaces.yaml` defines cluster-scoped Namespace objects; they are not namespaced, so the `namespace: infra` only applies to redis/kafka/postgres.
+
+6. **Update Argo CD shared-infra Application**  
+   In `overlays/gke/shared-infra-application.yaml`, set:
+   ```yaml
+   spec:
+     destination:
+       namespace: infra
+       server: https://kubernetes.default.svc
+   ```
+   So that the kustomize output (redis, kafka, postgres) is applied to the `infra` namespace. (Namespace resources in namespaces.yaml are cluster-scoped and ignore destination namespace.)
+
+---
+
+### Phase 2: Point apps at shared infra (FQDN)
+
+7. **ip-visit – remove local infra, use FQDN**  
+   - In `manifests/ip-visit/kustomization.yaml`: remove `./base/infra/kafka` and `./base/infra/redis` from `resources`.
+   - In `manifests/ip-visit/base/app/counter/deployment.yaml`:
+     - `REDISADDRESS`: `redis-main.infra.svc.cluster.local:6379`
+     - `KAFKAADDRESS`: `kafka.infra.svc.cluster.local:9092`
+   - In `manifests/ip-visit/base/app/consumer-kafka/deployment.yaml`:
+     - `KAFKAADDRESS`: `kafka.infra.svc.cluster.local:9092`
+
+8. **shop – remove local infra, use FQDN**  
+   - In `manifests/shop/kustomization.yaml`: remove `./base/infra/postgres` and `./base/infra/kafka` from `resources`.
+   - In `manifests/shop/base/app/inventory-service/deployment.yaml`:  
+     Postgres URL → `postgresql://postgres:postgres@postgres.infra.svc.cluster.local:5432/inventory`
+   - In `manifests/shop/base/app/order-service/deployment.yaml`:  
+     Postgres URL → `postgresql://postgres:postgres@postgres.infra.svc.cluster.local:5432/orders`  
+     Kafka → `KAFKA_ADDRESS`: `kafka.infra.svc.cluster.local:9092`
+   - In `manifests/shop/base/app/delivery-service/deployment.yaml`:  
+     Postgres URL → `postgresql://postgres:postgres@postgres.infra.svc.cluster.local:5432/deliveries`  
+     Kafka → `KAFKA_ADDRESS`: `kafka.infra.svc.cluster.local:9092`
+   - In `manifests/shop/base/app/payment-service/deployment.yaml`: if it uses Postgres, update similarly.
+
+9. **shop-mirrord**  
+   In `manifests/shop-mirrord/kafka-client-config.yaml`, set the broker to:
+   `kafka.infra.svc.cluster.local:9092` (replace `kafka.shop.svc.cluster.local:9092`).
+
+---
+
+### Phase 3: Remove old per-app infra (optional cleanup)
+
+10. **Delete obsolete manifest directories** (after migration is verified on a cluster):
+    - `manifests/ip-visit/base/infra/` (redis + kafka)
+    - `manifests/shop/base/infra/` (kafka + postgres)
+
+---
+
+## Deployment order and Argo CD
+
+- **shared-infra** should be deployed (or synced) **before** ip-visit and shop, so that the `infra` namespace and Redis/Kafka/Postgres exist when app pods start.
+- Options:
+  - **Manual / documented:** Ensure `kubectl apply -k overlays/gke` (or Argo sync of the bootstrap app) runs first, then sync shared-infra before or with the app apps.
+  - **Sync waves (optional):** In the root GKE kustomization, you can’t easily order Argo Applications; ordering is usually done via an App-of-Apps with sync waves or by having shared-infra as a dependency. For simplicity, document that shared-infra is synced first, or use Argo’s “Sync waves” on the shared-infra Application (e.g. wave `-1`) so it syncs before apps that depend on it (if your Argo set-up supports it).
+
+---
+
+## Rollback
+
+- Revert manifest changes (restore infra under ip-visit and shop, revert FQDNs to short names).
+- Revert `overlays/gke/shared-infra-application.yaml` destination namespace if needed.
+- Optionally delete the `infra` namespace and PVCs in `infra` if you recreated infra in app namespaces.
+
+---
+
+## Data / runtime considerations
+
+- **Kafka:** One shared cluster. Existing topics from ip-visit and shop will not exist on the new cluster; any persistent data in the old per-namespace Kafka PVCs is separate. For a demo/playground this is usually acceptable (apps recreate topics or handle empty state).
+- **Redis:** ip-visit counter state will start empty on the new Redis instance.
+- **Postgres:** New instance in `infra` will run init scripts (inventory, orders, deliveries). Any data in the current shop Postgres is in the old `shop` namespace PVCs; not migrated automatically.
+
+If you need to preserve data, you would plan a one-off migration (e.g. dump/restore Postgres, or accept Redis/Kafka as ephemeral for this cutover).
+
+---
+
+## Summary
+
+| Action | Where |
+|--------|--------|
+| Add `infra` namespace | `manifests/infrastructure/namespaces.yaml` |
+| Add redis, kafka, postgres | New dirs under `manifests/infrastructure/`, kustomization points to them + `namespace: infra` |
+| shared-infra destination | `overlays/gke/shared-infra-application.yaml` → `namespace: infra` |
+| ip-visit | Remove base/infra refs; counter + consumer-kafka use `*.infra.svc.cluster.local` |
+| shop | Remove base/infra refs; all DB/Kafka URLs use `*.infra.svc.cluster.local` |
+| shop-mirrord | Kafka broker → `kafka.infra.svc.cluster.local:9092` |
+| Cleanup (optional) | Remove `manifests/ip-visit/base/infra/`, `manifests/shop/base/infra/` |
+
+After this, all shared infrastructure lives in the **infra** namespace and is reused by ip-visit and shop.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# docs/
+
+Project context and planning documents for humans and AI agents.
+
+- **Start here:** [AI_ROOT_CONTEXT.md](AI_ROOT_CONTEXT.md) – project overview, layout, deployment.
+- **Pattern we use:** [AGENTIC-CONTEXT-GIT-PATTERN.md](AGENTIC-CONTEXT-GIT-PATTERN.md) – how we commit context/planning with feature work.
+- **Feature/area docs:** Add planning, end-state, or migration docs here (e.g. `SHOP-EXPERIENCE-END-STATE.md`, `INFRA-NAMESPACE-MIGRATION.md`) and commit them on the same branch as the implementation.
+
+Root [AGENTS.md](../AGENTS.md) points agents at this folder.

--- a/docs/SHOP-EXPERIENCE-END-STATE.md
+++ b/docs/SHOP-EXPERIENCE-END-STATE.md
@@ -1,0 +1,93 @@
+# Shop experience – end state and schema
+
+**Goal:** Minimal schema, minimal UI, slick UX. Inspired by Nike SNKRS (clean, product-focused) with a simple side-by-side layout like nopcommerce (image left, details right).
+
+---
+
+## Target UX
+
+1. **Product list (catalogue)**  
+   Card per product: **image**, name, price. Click → product detail. Minimal clutter.
+
+2. **Product detail**  
+   Single page per product, side-by-side:
+   - **Left:** One main product photo (large). Optional: small thumbnails or arrows to swap image later; v1 = single photo only.
+   - **Right:** Product name (optionally two lines: model + variant), price, description. Add to cart.
+
+3. **Rest of flow**  
+   Cart → Checkout → Order confirmation (existing flow; no schema change for this doc).
+
+---
+
+## What we’re incorporating (from Nike-style + simple side-by-side)
+
+| Element        | Source idea        | Implementation                    |
+|----------------|--------------------|-----------------------------------|
+| Product name   | Nike (model + name)| One `name`; optional `subtitle`  |
+| Price          | Both               | Keep `price_cents`                |
+| Description    | Nike (long copy)   | Keep `description` (TEXT)          |
+| Single photo   | Nike + nopcommerce | Add `image_url` (one per product)  |
+
+**Simplistic schema:** one table, one image URL per product. No categories, SKUs, or multi-image gallery in v1.
+
+---
+
+## Schema impact: `products` table
+
+**Current:**
+
+```text
+id, name, description, price_cents, stock, created_at
+```
+
+**Target (minimal):**
+
+| Column        | Type         | Notes                                      |
+|---------------|--------------|--------------------------------------------|
+| id            | SERIAL PK    | Unchanged                                  |
+| name          | VARCHAR(255) | Unchanged; main title                      |
+| subtitle      | VARCHAR(255) | Optional; e.g. "Persian Violet and Glacier Blue" for two-line Nike-style title. Nullable. |
+| description   | TEXT         | Unchanged; long copy                       |
+| price_cents   | INTEGER      | Unchanged                                  |
+| stock         | INTEGER      | Unchanged                                  |
+| image_url     | VARCHAR(512) | **New.** Single product image URL. Nullable for backfill. |
+| created_at    | TIMESTAMPTZ  | Unchanged                                  |
+
+**Why one `image_url`:** Keeps schema and UI simple. Frontend shows one main image; we can add a gallery (e.g. `image_urls TEXT[]` or a separate table) later if needed.
+
+**Why optional `subtitle`:** Supports the Nike-style “G.T. Cut 4 / Persian Violet and Glacier Blue” two-line treatment without forcing every product to have two fields. If null, UI shows only `name`.
+
+---
+
+## Implementation checklist (high level)
+
+1. **Schema**
+   - In `inventory-service`: add `image_url` (and optionally `subtitle`) to `CREATE TABLE` and seed data.
+   - Migration: `ALTER TABLE` for existing DBs, or rely on `CREATE TABLE IF NOT EXISTS` + new columns only for fresh deploys (if acceptable).
+
+2. **Inventory API**
+   - Include `image_url` (and `subtitle` if added) in `GET /products` and `GET /products/:id`.
+
+3. **Frontend**
+   - **Product list:** Show product image (from `image_url`), name, price; link to `/products/[id]`.
+   - **Product detail:** New page `/products/[id]` – side-by-side: image left, name (and subtitle if present), price, description, add to cart. Minimal, clean layout.
+
+4. **Assets**
+   - Seed products need `image_url` values (hosted image URLs or paths under `/public` and referenced as absolute paths).
+
+---
+
+## Out of scope for v1 (keep it minimal)
+
+- Multiple images per product (gallery).
+- Categories, tags, or filters.
+- SKU in DB (can add later if needed).
+- Variants (e.g. size/color) – single product per row only.
+
+---
+
+## Summary
+
+- **Schema:** Add `image_url`; optionally add `subtitle`. Everything else stays as-is.
+- **UX:** List with image + name + price → detail with single photo left, details right, minimal and slick.
+- **Flow:** List → Detail → Cart → Checkout (unchanged); only product data and product UI change.


### PR DESCRIPTION
- Add root AGENTS.md pointing to docs/ and conventions
- Add docs/AI_ROOT_CONTEXT.md (project overview, layout, deployment)
- Add docs/AGENTIC-CONTEXT-GIT-PATTERN.md (how we commit context with work)
- Add docs/README.md (folder purpose)
- Add docs/INFRA-NAMESPACE-MIGRATION.md, docs/SHOP-EXPERIENCE-END-STATE.md as examples of planning/migration docs in docs/