### PR TITLE
fix(shop): remove basePath from Link hrefs to fix /shop/shop 404

### DIFF
--- a/apps/shop/metal-mart-frontend/src/app/cart/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/cart/page.tsx
@@ -76,7 +76,7 @@ export default function CartPage() {
             <div className="rounded-xl border border-slate-200 bg-slate-50 px-8 py-16 text-center">
               <p className="text-lg text-slate-600">Your cart is empty.</p>
               <Link
-                href={`${basePath}/products`}
+                href="/products"
                 className="btn-primary mt-6 inline-block rounded-xl px-6 py-2.5 font-medium focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
               >
                 Browse products
@@ -134,7 +134,7 @@ export default function CartPage() {
                   Total: ${(totalCents / 100).toFixed(2)}
                 </p>
                 <Link
-                  href={`${basePath}/checkout`}
+                  href="/checkout"
                   className="btn-primary inline-flex w-fit items-center justify-center rounded-xl px-8 py-3 font-semibold focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
                 >
                   Checkout

--- a/apps/shop/metal-mart-frontend/src/app/checkout/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/checkout/page.tsx
@@ -89,7 +89,7 @@ export default function CheckoutPage() {
           <h1 className="text-2xl font-bold text-green-600">Order placed!</h1>
           <p className="text-slate-600">Order ID: {orderId}</p>
           <Link
-            href={`${basePath}/orders/${orderId}`}
+            href={`/orders/${orderId}`}
             className="btn-primary rounded-xl px-8 py-3 font-semibold focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
           >
             Track order
@@ -107,7 +107,7 @@ export default function CheckoutPage() {
           <div className="rounded-xl border border-slate-200 bg-slate-50 px-8 py-16 text-center">
             <p className="text-lg text-slate-600">Cart is empty. Add items first.</p>
             <Link
-              href={`${basePath}/products`}
+              href="/products"
               className="btn-primary mt-6 inline-block rounded-xl px-6 py-2.5 font-medium focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
             >
               Browse products

--- a/apps/shop/metal-mart-frontend/src/app/orders/[id]/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/orders/[id]/page.tsx
@@ -129,7 +129,7 @@ export default function OrderPage() {
             <div className="rounded-xl border border-slate-200 bg-slate-50 px-8 py-16 text-center">
               <p className="text-slate-600">Order not found</p>
               <Link
-                href={`${basePath}/products`}
+                href="/products"
                 className="mt-6 inline-block text-[#6a4ff5] hover:text-[#5a3fe5]"
               >
                 ← Back to products

--- a/apps/shop/metal-mart-frontend/src/app/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/page.tsx
@@ -25,7 +25,7 @@ function ProductTile({
   variant: "featured" | "standard" | "wide";
   delay?: number;
 }) {
-  const href = `${basePath}/products/${product.id}`;
+  const href = `/products/${product.id}`;
   const price = `$${(product.price_cents / 100).toFixed(2)}`;
 
   if (variant === "featured") {
@@ -245,7 +245,7 @@ export default function Home() {
 
                 <div className="mt-10 flex justify-center">
                   <Link
-                    href={`${basePath}/products`}
+                    href="/products"
                     className="text-sm font-medium text-[#6a4ff5] hover:text-[#5a3fe5] hover:underline"
                   >
                     View all products →
@@ -256,7 +256,7 @@ export default function Home() {
               <div className="rounded-2xl border border-slate-200 bg-slate-50 px-8 py-16 text-center">
                 <p className="text-slate-600">No products yet.</p>
                 <Link
-                  href={`${basePath}/products`}
+                  href="/products"
                   className="btn-primary mt-4 inline-block rounded-xl px-6 py-2.5 text-sm font-medium"
                 >
                   Browse products

--- a/apps/shop/metal-mart-frontend/src/app/products/[id]/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/[id]/page.tsx
@@ -55,7 +55,7 @@ export default function ProductDetailPage() {
             {error || "Product not found"}
           </p>
           <Link
-            href={`${basePath}/products`}
+            href="/products"
             className="mt-4 inline-block text-[#6a4ff5] hover:text-[#5a3fe5]"
           >
             ← Back to products
@@ -95,13 +95,13 @@ export default function ProductDetailPage() {
               <p className="mt-4 text-sm text-slate-500">In stock: {product.stock}</p>
               <div className="mt-10 flex flex-col gap-4 sm:flex-row">
                 <Link
-                  href={`${basePath}/cart?add=${product.id}`}
+                  href={`/cart?add=${product.id}`}
                   className="btn-primary inline-flex w-fit items-center justify-center rounded-xl px-8 py-3.5 font-semibold focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
                 >
                   Add to cart
                 </Link>
                 <Link
-                  href={`${basePath}/products`}
+                  href="/products"
                   className="btn-secondary inline-flex items-center justify-center rounded-xl px-6 py-3 font-medium focus:outline-none focus:ring-2 focus:ring-amber-400/40 focus:ring-offset-2"
                 >
                   ← Back to products

--- a/apps/shop/metal-mart-frontend/src/app/products/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/page.tsx
@@ -62,7 +62,7 @@ export default function ProductsPage() {
             {products.map((p, i) => (
               <Link
                 key={p.id}
-                href={`${basePath}/products/${p.id}`}
+                href={`/products/${p.id}`}
                 className="group flex flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal"
                 style={{ animationDelay: `${i * 0.06}s` }}
               >

--- a/apps/shop/metal-mart-frontend/src/components/Header.tsx
+++ b/apps/shop/metal-mart-frontend/src/components/Header.tsx
@@ -2,8 +2,6 @@
 
 import Link from "next/link";
 
-const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
-
 type HeaderProps = {
   /** Show "Official MetalBear Swag" subtitle (home page only) */
   showSubtitle?: boolean;
@@ -14,7 +12,7 @@ export default function Header({ showSubtitle = false }: HeaderProps) {
     <header className="sticky top-0 z-10 border-b border-slate-200 bg-white/95 backdrop-blur-sm">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
         <Link
-          href={basePath || "/"}
+          href="/"
           className="text-xl font-bold tracking-tight text-[#6a4ff5] hover:text-[#5a3fe5] focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2 rounded"
         >
           MetalMart
@@ -25,13 +23,13 @@ export default function Header({ showSubtitle = false }: HeaderProps) {
           )}
           <nav className="flex gap-6" aria-label="Main navigation">
             <Link
-              href={`${basePath}/products`}
+              href="/products"
               className="text-sm font-medium text-slate-600 hover:text-slate-900"
             >
               Products
             </Link>
             <Link
-              href={`${basePath}/cart`}
+              href="/cart"
               className="text-sm font-medium text-slate-600 hover:text-slate-900"
             >
               Cart


### PR DESCRIPTION
Next.js automatically prepends basePath to Link hrefs. Using basePath in href caused double prefix (/shop/shop). Use relative paths for Link; keep basePath for fetch and history.replaceState.