### PR TITLE
feat(ci): auto-deploy metal-mart-frontend on merge

### DIFF
--- a/.github/workflows/build-metal-mart-frontend.yaml
+++ b/.github/workflows/build-metal-mart-frontend.yaml
@@ -2,6 +2,9 @@ name: Release metal mart frontend
 on:
   push:
     branches: [main]
+    paths:
+      - "apps/shop/metal-mart-frontend/**"
+      - ".github/workflows/build-metal-mart-frontend.yaml"
   workflow_dispatch:
 jobs:
   image:
@@ -32,3 +35,31 @@ jobs:
           tags: |
             ghcr.io/metalbear-co/playground-metal-mart-frontend:latest
             ghcr.io/metalbear-co/playground-metal-mart-frontend:${{ github.sha }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: image
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Update deployment image
+        run: |
+          IMAGE="ghcr.io/metalbear-co/playground-metal-mart-frontend:${{ github.sha }}"
+          DEPLOY_FILE="manifests/shop/base/app/metal-mart-frontend/deployment.yaml"
+          sed -i "s|image: ghcr.io/metalbear-co/playground-metal-mart-frontend:.*|image: ${IMAGE}|" "$DEPLOY_FILE"
+          grep "image:" "$DEPLOY_FILE"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add manifests/shop/base/app/metal-mart-frontend/deployment.yaml
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore(shop): deploy metal-mart-frontend ${{ github.sha }} [skip ci]"
+            git push
+          fi


### PR DESCRIPTION
- Add deploy job that updates deployment manifest with image SHA
- Argo CD syncs and rolls out new pods when manifest changes
- Path filter: only run when frontend source changes (avoids deploy loop)