### PR TITLE
Disable Docker build cache for visualization-shop backend

### DIFF
--- a/.github/workflows/build-visualization-shop-backend.yaml
+++ b/.github/workflows/build-visualization-shop-backend.yaml
@@ -36,6 +36,7 @@ jobs:
           file: ./apps/visualization-shop/visualization-backend/Dockerfile
           platforms: linux/amd64
           push: true
+          no-cache: true
           tags: |
             ghcr.io/metalbear-co/visualization-shop-backend:latest
             ghcr.io/metalbear-co/visualization-shop-backend:${{ github.sha }}


### PR DESCRIPTION
## Summary
- Adds `no-cache: true` to the Docker build step to fix stale source code being served from cached layers

## Test plan
- [ ] Merge, wait for CI, restart deployment, and verify `/visualization-shop/api/operator-status` returns JSON

Made with [Cursor](https://cursor.com)