### PR TITLE
Demo/preview env ci + WIF auth

### DIFF
--- a/.github/workflows/preview-env-pr.yml
+++ b/.github/workflows/preview-env-pr.yml
@@ -5,13 +5,9 @@ name: Preview Environment (PR)
 
 on:
   pull_request:
+    branches:
+      - main
     types: [opened, synchronize, reopened, closed]
-    paths:
-      - "apps/ip-visit/ip-visit-counter/**"
-      - "apps/ip-visit/ip-visit-frontend/**"
-      - ".github/workflows/preview-env-pr.yml"
-      - "apps/ip-visit/ip-visit-counter/mirrord-preview.json"
-      - "apps/ip-visit/ip-visit-frontend/mirrord-preview.json"
 
 concurrency:
   group: preview-env-${{ github.event.pull_request.number }}
@@ -25,7 +21,7 @@ env:
 jobs:
   preview-start:
     name: Start preview (build, push, start, comment)
-    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'demo/preview-env-ci'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -152,7 +148,7 @@ jobs:
 
   preview-stop:
     name: Stop preview on merge/close
-    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'demo/preview-env-ci'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/preview-env-pr.yml
+++ b/.github/workflows/preview-env-pr.yml
@@ -1,6 +1,6 @@
 # mirrord Preview Environment: create on PR, delete on merge/close.
 # Builds frontend + counter, starts two preview pods (same key), posts link + header in comment.
-# Requires: KUBECONFIG_BASE64 secret, mirrord operator with Enterprise license.
+# Requires: GCP_WIF_PROVIDER + GCP_SERVICE_ACCOUNT secrets, mirrord operator with Enterprise license.
 name: Preview Environment (PR)
 
 on:
@@ -32,6 +32,7 @@ jobs:
       contents: read
       packages: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,12 +70,18 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Configure kubeconfig
-        run: |
-          mkdir -p $HOME/.kube
-          echo "${{ secrets.KUBECONFIG_BASE64 }}" | base64 -d > $HOME/.kube/config
-          chmod 600 $HOME/.kube/config
-          kubectl get ns ip-visit-counter >/dev/null
+      - name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: playground-cluster-1
+          location: us-central1-c
+          project_id: playground-383912
 
       - name: Install mirrord
         run: |
@@ -148,15 +155,25 @@ jobs:
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure kubeconfig
-        run: |
-          mkdir -p $HOME/.kube
-          echo "${{ secrets.KUBECONFIG_BASE64 }}" | base64 -d > $HOME/.kube/config
-          chmod 600 $HOME/.kube/config
+      - name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: playground-cluster-1
+          location: us-central1-c
+          project_id: playground-383912
 
       - name: Install mirrord
         run: |

--- a/.github/workflows/preview-env-pr.yml
+++ b/.github/workflows/preview-env-pr.yml
@@ -1,0 +1,168 @@
+# mirrord Preview Environment: create on PR, delete on merge/close.
+# Builds frontend + counter, starts two preview pods (same key), posts link + header in comment.
+# Requires: KUBECONFIG_BASE64 secret, mirrord operator with Enterprise license.
+name: Preview Environment (PR)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - "apps/ip-visit/ip-visit-counter/**"
+      - "apps/ip-visit/ip-visit-frontend/**"
+      - ".github/workflows/preview-env-pr.yml"
+      - "apps/ip-visit/ip-visit-counter/mirrord-preview.json"
+      - "apps/ip-visit/ip-visit-frontend/mirrord-preview.json"
+
+concurrency:
+  group: preview-env-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  PREVIEW_KEY: "pr-${{ github.event.pull_request.number }}"
+  COUNTER_IMAGE: "ghcr.io/metalbear-co/playground-ip-visit-counter:preview-pr-${{ github.event.pull_request.number }}-${{ github.sha }}"
+  FRONTEND_IMAGE: "ghcr.io/metalbear-co/playground-ip-visit-frontend:preview-pr-${{ github.event.pull_request.number }}-${{ github.sha }}"
+
+jobs:
+  preview-start:
+    name: Start preview (build, push, start, comment)
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push counter image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: apps/ip-visit/ip-visit-counter/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.COUNTER_IMAGE }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: apps/ip-visit/ip-visit-frontend
+          file: apps/ip-visit/ip-visit-frontend/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.FRONTEND_IMAGE }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG_BASE64 }}" | base64 -d > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
+          kubectl get ns ip-visit-counter >/dev/null
+
+      - name: Install mirrord
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/metalbear-co/mirrord/main/scripts/install.sh | bash
+          mirrord --version
+
+      - name: Start mirrord preview (counter)
+        run: |
+          mirrord preview start \
+            -f apps/ip-visit/ip-visit-counter/mirrord-preview.json \
+            -i "${{ env.COUNTER_IMAGE }}" \
+            -k "${{ env.PREVIEW_KEY }}" \
+            --timeout 600
+
+      - name: Start mirrord preview (frontend)
+        run: |
+          mirrord preview start \
+            -f apps/ip-visit/ip-visit-frontend/mirrord-preview.json \
+            -i "${{ env.FRONTEND_IMAGE }}" \
+            -k "${{ env.PREVIEW_KEY }}" \
+            --timeout 600
+
+      - name: Post PR comment with preview link and header
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const key = `${{ env.PREVIEW_KEY }}`;
+            const url = 'https://playground.metalbear.dev';
+            const body = `## mirrord Preview Environment
+
+            A preview environment is running for this PR (frontend + counter).
+
+            | | |
+            |---|---|
+            | **Preview URL** | [${url}](${url}) |
+            | **Header** | \`X-PG-Tenant: ${key}\` |
+
+            To send traffic to this preview:
+            - Use the [mirrord Browser Extension](https://metalbear.com/mirrord/docs/using-mirrord/browser-extension) and set the header for this URL, or
+            - \`curl -H "X-PG-Tenant: ${key}" ${url}/count\`
+
+            The UI will show "Preview: ${key}" when the header is set.
+
+            *Preview is stopped when the PR is merged or closed.*
+            `;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComment = comments.find(c => c.body && c.body.includes('## mirrord Preview Environment'));
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  preview-stop:
+    name: Stop preview on merge/close
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG_BASE64 }}" | base64 -d > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
+
+      - name: Install mirrord
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/metalbear-co/mirrord/main/scripts/install.sh | bash
+          mirrord --version
+
+      - name: Stop mirrord preview
+        run: |
+          mirrord preview stop -k "pr-${{ github.event.pull_request.number }}" || true

--- a/apps/ip-visit/ip-visit-counter/README.md
+++ b/apps/ip-visit/ip-visit-counter/README.md
@@ -2,3 +2,12 @@
 
 This microservice counts the number of visits to a given IP address by using Redis and writes the IP to Kafka.
 This is part of MetalBear's playground.
+
+## mirrord Preview Environment (CI)
+
+On pull requests that touch ip-visit-counter or ip-visit-frontend, CI builds both images, starts two preview pods (frontend + counter) with the same key (e.g. `pr-<number>`), and posts a comment with the shared playground link and the header to use. On PR merge or close, the preview is stopped.
+
+- **Workflow:** [.github/workflows/preview-env-pr.yml](../../.github/workflows/preview-env-pr.yml)
+- **Preview configs:** [mirrord-preview.json](./mirrord-preview.json) (counter), [../ip-visit-frontend/mirrord-preview.json](../ip-visit-frontend/mirrord-preview.json) (frontend)
+
+Cluster access (kubeconfig) is configured in GitHub secrets (`KUBECONFIG_BASE64`), not in code.

--- a/apps/ip-visit/ip-visit-counter/README.md
+++ b/apps/ip-visit/ip-visit-counter/README.md
@@ -10,4 +10,4 @@ On pull requests that touch ip-visit-counter or ip-visit-frontend, CI builds bot
 - **Workflow:** [.github/workflows/preview-env-pr.yml](../../.github/workflows/preview-env-pr.yml)
 - **Preview configs:** [mirrord-preview.json](./mirrord-preview.json) (counter), [../ip-visit-frontend/mirrord-preview.json](../ip-visit-frontend/mirrord-preview.json) (frontend)
 
-Cluster access (kubeconfig) is configured in GitHub secrets (`KUBECONFIG_BASE64`), not in code.
+Cluster access is obtained via Workload Identity Federation (GitHub OIDC → GCP) using the `GCP_WIF_PROVIDER` and `GCP_SERVICE_ACCOUNT` secrets; no kubeconfig is stored in GitHub.

--- a/apps/ip-visit/ip-visit-counter/main.go
+++ b/apps/ip-visit/ip-visit-counter/main.go
@@ -259,7 +259,11 @@ func getCount(c *gin.Context) {
 		return
 	}
 
-	c.JSON(200, gin.H{"count": count, "text": ResponseString + "hi", "info": ipInfo, "info2": ipInfo2})
+	demoMarker := "production"
+	if tenant != "" {
+		demoMarker = tenant
+	}
+	c.JSON(200, gin.H{"count": count, "text": ResponseString + "hi", "info": ipInfo, "info2": ipInfo2, "demo_marker": demoMarker})
 }
 
 func main() {

--- a/apps/ip-visit/ip-visit-counter/mirrord-preview.json
+++ b/apps/ip-visit/ip-visit-counter/mirrord-preview.json
@@ -1,0 +1,20 @@
+{
+  "target": {
+    "path": "deployment/ip-visit-counter",
+    "namespace": "ip-visit-counter"
+  },
+  "feature": {
+    "preview": {
+      "ttl_mins": 120,
+      "creation_timeout_secs": 600
+    },
+    "network": {
+      "incoming": {
+        "mode": "steal",
+        "http_filter": {
+          "header_filter": "X-PG-Tenant: {{ key }}"
+        }
+      }
+    }
+  }
+}

--- a/apps/ip-visit/ip-visit-frontend/app/page.tsx
+++ b/apps/ip-visit/ip-visit-frontend/app/page.tsx
@@ -23,7 +23,7 @@ export default function Home() {
   console.log
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24 bg-gray-100">
-      <IPInfo ip={data.info.ip} count={data.count} text={data.text} name={data.info.name} />
+      <IPInfo ip={data.info.ip} count={data.count} text={data.text} name={data.info.name} demoMarker={data.demo_marker} />
     </main>
   )
 }

--- a/apps/ip-visit/ip-visit-frontend/components/ipinfo.tsx
+++ b/apps/ip-visit/ip-visit-frontend/components/ipinfo.tsx
@@ -5,11 +5,19 @@
 import { CardTitle, CardHeader, CardContent, Card } from "@/components/ui/card"
 
 
-export function IPInfo({ count, ip, name, text }: { count: number, ip: string, name: string, text: string }) {
+export function IPInfo({ count, ip, name, text, demoMarker }: { count: number, ip: string, name: string, text: string; demoMarker?: string }) {
+  const isPreview = demoMarker && demoMarker !== "production";
   return (
       <Card className="max-w-md w-full mx-4">
         <CardHeader>
-          <CardTitle className="text-lg font-bold">API Data</CardTitle>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg font-bold">API Data</CardTitle>
+            {isPreview ? (
+              <span className="rounded bg-amber-100 px-2 py-0.5 text-sm font-medium text-amber-800">Preview: {demoMarker}</span>
+            ) : (
+              <span className="rounded bg-slate-100 px-2 py-0.5 text-sm font-medium text-slate-600">Production</span>
+            )}
+          </div>
         </CardHeader>
         <CardContent>
           <div className="grid gap-2">

--- a/apps/ip-visit/ip-visit-frontend/mirrord-preview.json
+++ b/apps/ip-visit/ip-visit-frontend/mirrord-preview.json
@@ -1,0 +1,20 @@
+{
+  "target": {
+    "path": "deployment/ip-visit-frontend",
+    "namespace": "ip-visit-counter"
+  },
+  "feature": {
+    "preview": {
+      "ttl_mins": 120,
+      "creation_timeout_secs": 600
+    },
+    "network": {
+      "incoming": {
+        "mode": "steal",
+        "http_filter": {
+          "header_filter": "X-PG-Tenant: {{ key }}"
+        }
+      }
+    }
+  }
+}

--- a/docs/preview-env-ci.md
+++ b/docs/preview-env-ci.md
@@ -1,0 +1,17 @@
+# mirrord Preview Environments in CI
+
+This doc summarizes the preview env CI flow used for the ip-visit demo. It can be reused as a reference for similar setups.
+
+## Flow
+
+1. **On PR open / push:** Workflow builds frontend and counter images, pushes them with tags `preview-pr-<number>-<sha>`, runs `mirrord preview start` twice (one per deployment) with the same key `pr-<number>`, and posts or updates a single PR comment with the preview URL and header (`X-PG-Tenant: pr-<number>`).
+2. **Reviewers:** Open the shared link and set the header (e.g. via the [mirrord Browser Extension](https://metalbear.com/mirrord/docs/using-mirrord/browser-extension)). The UI shows "Preview: pr-<number>" when the request hits the preview pods.
+3. **On PR merge or close:** Workflow runs `mirrord preview stop -k pr-<number>` to tear down the preview pods.
+
+## References
+
+- [.github/workflows/preview-env-pr.yml](../.github/workflows/preview-env-pr.yml) – workflow definition
+- [apps/ip-visit/ip-visit-counter/mirrord-preview.json](../apps/ip-visit/ip-visit-counter/mirrord-preview.json) – counter preview config
+- [apps/ip-visit/ip-visit-frontend/mirrord-preview.json](../apps/ip-visit/ip-visit-frontend/mirrord-preview.json) – frontend preview config
+- [mirrord Preview Environments](https://metalbear.com/mirrord/docs/using-mirrord/preview-environments)
+- [mirrord Browser Extension](https://metalbear.com/mirrord/docs/using-mirrord/browser-extension)


### PR DESCRIPTION
### Summary

This PR adds a **mirrord Preview Environment CI demo** for the `ip-visit` app and wires it to run only for the **`demo/preview-env-ci` → `main`** PR, using **Workload Identity Federation (WIF)** instead of a stored kubeconfig.

---

### What this PR does

- **Preview env on PRs (demo branch only)**
  - Workflow: `.github/workflows/preview-env-pr.yml`
  - Trigger:
    - `on: pull_request` into `main`
    - Jobs run **only when**:
      - `github.head_ref == 'demo/preview-env-ci'` (demo branch), and
      - PR is from this repo (no forks).
  - Behavior for that demo PR:
    - Build preview images for:
      - `apps/ip-visit/ip-visit-counter`
      - `apps/ip-visit/ip-visit-frontend`
    - Start **two mirrord preview pods** (frontend + counter) with the same key (`pr-<number>`).
    - Post/update a PR comment with:
      - Playground URL: `https://playground.metalbear.dev`
      - Header: `X-PG-Tenant: pr-<number>` to route traffic to the preview.
    - On PR close: `mirrord preview stop -k pr-<number>` to tear down the preview.

- **Backend: echo preview key**
  - `apps/ip-visit/ip-visit-counter/main.go`:
    - `/count` now returns a `demo_marker` field:
      - If `X-PG-Tenant` is present: `demo_marker` = header value (e.g. `pr-123`).
      - Otherwise: `demo_marker` = `"production"`.

- **Frontend: show Preview/Production badge**
  - `apps/ip-visit/ip-visit-frontend/app/page.tsx`:
    - Passes `data.demo_marker` to `IPInfo`.
  - `apps/ip-visit/ip-visit-frontend/components/ipinfo.tsx`:
    - Shows a badge in the card header:
      - `Preview: pr-123` when `demo_marker != "production"`.
      - `Production` otherwise.
  - This makes the shared playground link visibly indicate when you’re hitting the preview env (via mirrord Browser Extension or `curl` with the header).

- **mirrord preview configs**
  - `apps/ip-visit/ip-visit-counter/mirrord-preview.json`
  - `apps/ip-visit/ip-visit-frontend/mirrord-preview.json`
  - Both:
    - Target their respective deployments in `ip-visit-counter` namespace.
    - Use `feature.preview` with TTL + `creation_timeout_secs`.
    - Use `mode: "steal"` with `http_filter.header_filter: "X-PG-Tenant: {{ key }}"` so `X-PG-Tenant: pr-<number>` routes to the preview pods.

- **GitHub Actions workflow auth (WIF, no kubeconfig)**
  - `.github/workflows/preview-env-pr.yml`:
    - Uses **Workload Identity Federation**:
      - `google-github-actions/auth@v2` with:
        - `workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}`
        - `service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}`
      - `google-github-actions/get-gke-credentials@v2` with:
        - `cluster_name: playground-cluster-1`
        - `location: us-central1-c`
        - `project_id: playground-383912`
    - Removes the old `KUBECONFIG_BASE64`-based kubeconfig step; no kubeconfig is stored in GitHub.

- **Docs**
  - `apps/ip-visit/ip-visit-counter/README.md`:
    - Adds a “mirrord Preview Environment (CI)” section pointing to:
      - Workflow: `.github/workflows/preview-env-pr.yml`
      - Preview configs: `mirrord-preview.json` in counter and frontend.
    - Notes that cluster access is via WIF (`GCP_WIF_PROVIDER` + `GCP_SERVICE_ACCOUNT`), not kubeconfig.
  - `docs/preview-env-ci.md`:
    - High-level description of the CI preview flow and links to configs/workflow.

---

### How to run the demo

1. Keep a branch named `demo/preview-env-ci` (rebased from `main` as needed).
2. Open a PR from `demo/preview-env-ci` → `main`.
3. Let the **Preview Environment (PR)** workflow run; check the PR comment for:
   - Playground URL.
   - Header: `X-PG-Tenant: pr-<number>`.
4. Use the mirrord Browser Extension (or `curl -H "X-PG-Tenant: pr-<number>" …`) to send traffic to the preview.
5. In the ip-visit UI you’ll see:
   - `Preview: pr-<number>` when your traffic hits the preview pods.
   - `Production` otherwise.

On merging/closing that demo PR, the preview pods are automatically stopped.