### PR TITLE
feat(metal-mart): product detail dialog instead of full page

### DIFF
--- a/.github/workflows/preview-metal-mart-pr.yml
+++ b/.github/workflows/preview-metal-mart-pr.yml
@@ -127,6 +127,31 @@ jobs:
               });
             }
 
+      - name: Post preview link to Slack
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": { "type": "plain_text", "text": "mirrord Preview Environment - Metal Mart" }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*PR:*\n<${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}>" },
+                    { "type": "mrkdwn", "text": "*Preview URL:*\n<https://playground.metalbear.dev/shop|Open Preview>" },
+                    { "type": "mrkdwn", "text": "*Header:*\n`X-PG-Tenant: ${{ env.PREVIEW_KEY }}`" },
+                    { "type": "mrkdwn", "text": "*curl:*\n`curl -H \"X-PG-Tenant: ${{ env.PREVIEW_KEY }}\" https://playground.metalbear.dev/shop`" }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
   preview-stop:
     name: Stop preview on merge/close
     if: github.event.action == 'closed'

--- a/apps/shop/metal-mart-frontend/src/app/globals.css
+++ b/apps/shop/metal-mart-frontend/src/app/globals.css
@@ -91,6 +91,15 @@ a, button {
   animation: cardReveal 0.4s ease-out forwards;
 }
 
+/* Dialog backdrop fade-in */
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.animate-fade-in {
+  animation: fadeIn 0.15s ease-out forwards;
+}
+
 /* Hand-drawn underline (MetalBear-style accent) */
 .hand-drawn-underline {
   position: relative;

--- a/apps/shop/metal-mart-frontend/src/app/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/page.tsx
@@ -6,6 +6,7 @@ import Header from "@/components/Header";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import NewBadge from "@/components/NewBadge";
 import ProductImage from "@/components/ProductImage";
+import ProductDialog from "@/components/ProductDialog";
 import { getPrimaryImageUrl, type Product } from "@/lib/product";
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
@@ -15,23 +16,25 @@ function ProductTile({
   variant,
   delay = 0,
   elevated = false,
+  onSelect,
 }: {
   product: Product;
   variant: "featured" | "standard" | "wide";
   delay?: number;
   /** Above mascot on home page so card stays opaque */
   elevated?: boolean;
+  onSelect: (id: number) => void;
 }) {
-  const href = `/products/${product.id}`;
   const price = `$${(product.price_cents / 100).toFixed(2)}`;
 
   const elevatedClass = elevated ? "relative z-30" : "";
 
   if (variant === "featured") {
     return (
-      <Link
-        href={href}
-        className={`group relative flex h-full min-h-[280px] flex-col overflow-hidden rounded-2xl border border-slate-300 bg-slate-100 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-[#6a4ff5]/15 hover:border-[#6a4ff5]/30 animate-card-reveal ${elevatedClass}`}
+      <button
+        type="button"
+        onClick={() => onSelect(product.id)}
+        className={`group relative flex h-full min-h-[280px] w-full flex-col overflow-hidden rounded-2xl border border-slate-300 bg-slate-100 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-[#6a4ff5]/15 hover:border-[#6a4ff5]/30 animate-card-reveal text-left ${elevatedClass}`}
         style={{ animationDelay: `${delay}s` }}
       >
         {product.is_new && <NewBadge size="default" />}
@@ -60,15 +63,16 @@ function ProductTile({
             Shop now →
           </span>
         </div>
-      </Link>
+      </button>
     );
   }
 
   if (variant === "wide") {
     return (
-      <Link
-        href={href}
-        className={`group relative flex flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal sm:flex-row ${elevatedClass}`}
+      <button
+        type="button"
+        onClick={() => onSelect(product.id)}
+        className={`group relative flex w-full flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal text-left sm:flex-row ${elevatedClass}`}
         style={{ animationDelay: `${delay}s` }}
       >
         {product.is_new && <NewBadge size="default" />}
@@ -98,15 +102,16 @@ function ProductTile({
             </p>
           )}
         </div>
-      </Link>
+      </button>
     );
   }
 
   // standard
   return (
-    <Link
-      href={href}
-      className={`group relative flex flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal ${elevatedClass}`}
+    <button
+      type="button"
+      onClick={() => onSelect(product.id)}
+      className={`group relative flex w-full flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal text-left ${elevatedClass}`}
       style={{ animationDelay: `${delay}s` }}
     >
       {product.is_new && <NewBadge size="default" />}
@@ -131,7 +136,7 @@ function ProductTile({
         </h2>
         <p className="mt-1 font-semibold text-[#6a4ff5]">{price}</p>
       </div>
-    </Link>
+    </button>
   );
 }
 
@@ -139,6 +144,7 @@ export default function Home() {
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedProductId, setSelectedProductId] = useState<number | null>(null);
 
   useEffect(() => {
     fetch(`${basePath}/api/products`)
@@ -185,7 +191,7 @@ export default function Home() {
           <div className="mx-auto max-w-6xl">
             {hasProducts && (
               <h1 className="hand-drawn-underline mb-10 inline-block text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl md:text-5xl">
-                Featured products
+                Featured Swag
               </h1>
             )}
             {hasProducts ? (
@@ -207,7 +213,7 @@ export default function Home() {
                           : ""
                       }
                     >
-                      <ProductTile product={featured} variant="featured" delay={0} elevated />
+                      <ProductTile product={featured} variant="featured" delay={0} elevated onSelect={setSelectedProductId} />
                     </div>
                   )}
                   {/* Side tiles - products 2 and 3 stacked on the right (or single tile spans 2 rows) */}
@@ -215,18 +221,18 @@ export default function Home() {
                     <div
                       className={`md:col-span-2 ${rest[1] ? "md:row-span-1" : "md:row-span-2"}`}
                     >
-                      <ProductTile product={rest[0]} variant="standard" delay={0.06} elevated />
+                      <ProductTile product={rest[0]} variant="standard" delay={0.06} elevated onSelect={setSelectedProductId} />
                     </div>
                   )}
                   {rest[1] && (
                     <div className="md:col-span-2 md:row-span-1">
-                      <ProductTile product={rest[1]} variant="standard" delay={0.12} elevated />
+                      <ProductTile product={rest[1]} variant="standard" delay={0.12} elevated onSelect={setSelectedProductId} />
                     </div>
                   )}
                   {/* Bottom row - product 4 as wide horizontal tile */}
                   {rest[2] && (
                     <div className="md:col-span-4">
-                      <ProductTile product={rest[2]} variant="wide" delay={0.18} elevated />
+                      <ProductTile product={rest[2]} variant="wide" delay={0.18} elevated onSelect={setSelectedProductId} />
                     </div>
                   )}
                   {/* Products 5+ in a grid */}
@@ -239,6 +245,7 @@ export default function Home() {
                           variant="standard"
                           delay={0.24 + i * 0.06}
                           elevated
+                          onSelect={setSelectedProductId}
                         />
                       ))}
                     </div>
@@ -268,6 +275,7 @@ export default function Home() {
           </div>
         </section>
       </main>
+      <ProductDialog productId={selectedProductId} onClose={() => setSelectedProductId(null)} />
     </div>
   );
 }

--- a/apps/shop/metal-mart-frontend/src/app/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/page.tsx
@@ -26,7 +26,6 @@ function ProductTile({
   onSelect: (id: number) => void;
 }) {
   const price = `$${(product.price_cents / 100).toFixed(2)}`;
-
   const elevatedClass = elevated ? "relative z-30" : "";
 
   if (variant === "featured") {
@@ -60,7 +59,7 @@ function ProductTile({
           </h2>
           <p className="mt-1 text-lg font-semibold text-white/90">{price}</p>
           <span className="mt-3 inline-block text-sm font-medium text-white/90 underline-offset-2 group-hover:underline">
-            Shop now →
+            View details →
           </span>
         </div>
       </button>
@@ -275,6 +274,7 @@ export default function Home() {
           </div>
         </section>
       </main>
+
       <ProductDialog productId={selectedProductId} onClose={() => setSelectedProductId(null)} />
     </div>
   );

--- a/apps/shop/metal-mart-frontend/src/app/products/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/page.tsx
@@ -92,6 +92,7 @@ export default function ProductsPage() {
           </div>
         </div>
       </main>
+
       <ProductDialog productId={selectedProductId} onClose={() => setSelectedProductId(null)} />
     </div>
   );

--- a/apps/shop/metal-mart-frontend/src/app/products/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import Header from "@/components/Header";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import NewBadge from "@/components/NewBadge";
 import ProductImage from "@/components/ProductImage";
+import ProductDialog from "@/components/ProductDialog";
 import { getPrimaryImageUrl, type Product } from "@/lib/product";
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
@@ -14,6 +14,7 @@ export default function ProductsPage() {
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedProductId, setSelectedProductId] = useState<number | null>(null);
 
   useEffect(() => {
     fetch(`${basePath}/api/products`)
@@ -56,10 +57,11 @@ export default function ProductsPage() {
           </h1>
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
             {products.map((p, i) => (
-              <Link
+              <button
+                type="button"
                 key={p.id}
-                href={`/products/${p.id}`}
-                className="group relative flex flex-col overflow-hidden rounded-xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal"
+                onClick={() => setSelectedProductId(p.id)}
+                className="group relative flex w-full flex-col overflow-hidden rounded-xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal text-left"
                 style={{ animationDelay: `${i * 0.06}s` }}
               >
                 {p.is_new && <NewBadge size="default" />}
@@ -85,11 +87,12 @@ export default function ProductsPage() {
                   <p className="mt-2 text-lg font-semibold text-[#6a4ff5]">${(p.price_cents / 100).toFixed(2)}</p>
                   <p className="mt-auto pt-3 text-xs text-slate-500">In stock: {p.stock}</p>
                 </div>
-              </Link>
+              </button>
             ))}
           </div>
         </div>
       </main>
+      <ProductDialog productId={selectedProductId} onClose={() => setSelectedProductId(null)} />
     </div>
   );
 }

--- a/apps/shop/metal-mart-frontend/src/components/ProductDialog.tsx
+++ b/apps/shop/metal-mart-frontend/src/components/ProductDialog.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import NewBadge from "@/components/NewBadge";
+import ProductImage from "@/components/ProductImage";
+import { getImageUrls, type Product } from "@/lib/product";
+import LoadingSpinner from "@/components/LoadingSpinner";
+
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
+export default function ProductDialog({
+  productId,
+  onClose,
+}: {
+  productId: number | null;
+  onClose: () => void;
+}) {
+  const [product, setProduct] = useState<Product | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => {
+    if (!productId) return;
+    setLoading(true);
+    setError(null);
+    setProduct(null);
+    setSelectedIndex(0);
+    fetch(`${basePath}/api/products/${productId}`)
+      .then((r) => {
+        if (!r.ok) throw new Error("Product not found");
+        return r.json();
+      })
+      .then(setProduct)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [productId]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    if (!productId) return;
+    document.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [productId, handleKeyDown]);
+
+  if (!productId) return null;
+
+  const imageUrls = product ? getImageUrls(product) : [];
+  const labels = imageUrls.length === 2 ? ["Front", "Back"] : undefined;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-3xl max-h-[90vh] overflow-y-auto rounded-2xl bg-white shadow-2xl animate-card-reveal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Close button */}
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white/80 text-slate-500 shadow-sm backdrop-blur transition-colors hover:bg-white hover:text-slate-900"
+          aria-label="Close"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+
+        {loading && (
+          <div className="flex items-center justify-center p-16">
+            <LoadingSpinner />
+          </div>
+        )}
+
+        {error && (
+          <div className="p-8">
+            <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600">
+              {error}
+            </p>
+          </div>
+        )}
+
+        {product && (
+          <div className="grid gap-6 p-6 md:grid-cols-2 md:p-8">
+            {/* Image gallery */}
+            <div className="space-y-3">
+              <div className="relative aspect-square overflow-hidden rounded-xl border border-slate-200 bg-slate-50 shadow-lg">
+                {product.is_new && <NewBadge size="lg" />}
+                {imageUrls.length > 0 ? (
+                  <ProductImage
+                    src={imageUrls[selectedIndex]}
+                    alt={labels ? `${product.name} — ${labels[selectedIndex]}` : product.name}
+                    className="h-full w-full object-cover"
+                    fill
+                    sizes="(max-width: 768px) 100vw, 50vw"
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-slate-400">
+                    No image
+                  </div>
+                )}
+              </div>
+              {imageUrls.length > 1 && (
+                <div className="flex gap-2">
+                  {imageUrls.map((url, i) => (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => setSelectedIndex(i)}
+                      className={`relative h-16 w-16 shrink-0 overflow-hidden rounded-lg border-2 transition-colors ${
+                        selectedIndex === i
+                          ? "border-[#6a4ff5] ring-2 ring-[#6a4ff5]/30"
+                          : "border-slate-200 hover:border-slate-300"
+                      }`}
+                      aria-label={labels ? labels[i] : `Image ${i + 1}`}
+                    >
+                      <ProductImage
+                        src={url}
+                        alt=""
+                        width={64}
+                        height={64}
+                        className="h-full w-full object-cover"
+                      />
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Product details */}
+            <div className="flex flex-col">
+              <h2 className="text-2xl font-bold tracking-tight text-slate-900 md:text-3xl">
+                {product.name}
+              </h2>
+              <p className="mt-3 text-2xl font-semibold text-[#6a4ff5]">
+                ${(product.price_cents / 100).toFixed(2)}
+              </p>
+              {product.description && (
+                <p className="mt-4 text-slate-600 leading-relaxed">{product.description}</p>
+              )}
+              <p className="mt-3 text-sm text-slate-500">In stock: {product.stock}</p>
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href={`/cart?add=${product.id}`}
+                  className="btn-primary inline-flex w-fit items-center justify-center rounded-xl px-8 py-3.5 font-semibold focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
+                >
+                  Add to cart
+                </Link>
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="btn-secondary inline-flex items-center justify-center rounded-xl px-6 py-3 font-medium focus:outline-none focus:ring-2 focus:ring-amber-400/40 focus:ring-offset-2"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/shop/metal-mart-frontend/src/components/ProductDialog.tsx
+++ b/apps/shop/metal-mart-frontend/src/components/ProductDialog.tsx
@@ -61,11 +61,11 @@ export default function ProductDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in"
       onClick={onClose}
     >
       <div
-        className="relative w-full max-w-3xl max-h-[90vh] overflow-y-auto rounded-2xl bg-white shadow-2xl animate-card-reveal"
+        className="relative w-full max-w-3xl max-h-[90vh] overflow-y-auto rounded-2xl bg-white shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Close button */}
@@ -96,10 +96,10 @@ export default function ProductDialog({
         )}
 
         {product && (
-          <div className="grid gap-6 p-6 md:grid-cols-2 md:p-8">
-            {/* Image gallery */}
-            <div className="space-y-3">
-              <div className="relative aspect-square overflow-hidden rounded-xl border border-slate-200 bg-slate-50 shadow-lg">
+          <div className="grid md:grid-cols-2">
+            {/* Image side */}
+            <div className="p-6 space-y-3 bg-slate-50">
+              <div className="relative aspect-square overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
                 {product.is_new && <NewBadge size="lg" />}
                 {imageUrls.length > 0 ? (
                   <ProductImage
@@ -143,7 +143,7 @@ export default function ProductDialog({
             </div>
 
             {/* Product details */}
-            <div className="flex flex-col">
+            <div className="flex flex-col p-6">
               <h2 className="text-2xl font-bold tracking-tight text-slate-900 md:text-3xl">
                 {product.name}
               </h2>
@@ -154,9 +154,9 @@ export default function ProductDialog({
                 <p className="mt-4 text-slate-600 leading-relaxed">{product.description}</p>
               )}
               <p className="mt-3 text-sm text-slate-500">In stock: {product.stock}</p>
-              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <div className="mt-auto pt-8 flex flex-col gap-3 sm:flex-row">
                 <Link
-                  href={`/cart?add=${product.id}`}
+                  href={`${basePath}/cart?add=${product.id}`}
                   className="btn-primary inline-flex w-fit items-center justify-center rounded-xl px-8 py-3.5 font-semibold focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
                 >
                   Add to cart

--- a/apps/visualization-shop/visualization-frontend/src/app/VisualizationPage.tsx
+++ b/apps/visualization-shop/visualization-frontend/src/app/VisualizationPage.tsx
@@ -1661,7 +1661,7 @@ export default function VisualizationPage({ useQueueSplittingMock, useDbBranchMo
     });
   }, [previewSessions, dynamicNodePositions]);
 
-  // Build dynamic edges for PreviewSession nodes: operator → preview pod.
+  // Build dynamic edges for PreviewSession nodes: operator → preview pod, operator → target service.
   const previewSessionEdges = useMemo((): Edge[] => {
     if (previewSessions.length === 0) return [];
     const mirroredStyle = intentStyles.mirrored;
@@ -1673,9 +1673,10 @@ export default function VisualizationPage({ useQueueSplittingMock, useDbBranchMo
       labelStyle: { fontSize: 12, fontWeight: 600, fill: "#0F172A" },
     };
 
-    return previewSessions.map((session) => {
+    const edges: Edge[] = [];
+    for (const session of previewSessions) {
       const nodeId = `preview-${sanitizeHostname(session.name)}`;
-      return {
+      edges.push({
         id: `operator-to-${nodeId}`,
         source: "mirrord-operator",
         target: nodeId,
@@ -1691,9 +1692,30 @@ export default function VisualizationPage({ useQueueSplittingMock, useDbBranchMo
           strokeDasharray: mirroredStyle.dash,
         },
         ...edgeLabelDefaults,
-      };
-    });
-  }, [previewSessions]);
+      });
+
+      const targetArchNodeId = aliasIndex.get(session.target.name.toLowerCase());
+      if (targetArchNodeId) {
+        edges.push({
+          id: `${nodeId}-to-${targetArchNodeId}`,
+          source: nodeId,
+          target: targetArchNodeId,
+          label: "Target service",
+          type: "bezier",
+          sourceHandle: `${nodeId}-source-right`,
+          animated: true,
+          markerEnd: { type: MarkerType.ArrowClosed, width: 24, height: 24 },
+          style: {
+            stroke: "#0EA5E9",
+            strokeWidth: 2.75,
+            strokeDasharray: mirroredStyle.dash,
+          },
+          ...edgeLabelDefaults,
+        });
+      }
+    }
+    return edges;
+  }, [previewSessions, aliasIndex]);
 
   // Combine static edges with dynamic agent edges and kafka edges.
   // When multiple kafka topics exist, static local-to-layer and layer-to-agent are replaced


### PR DESCRIPTION
## Summary
- Added a `ProductDialog` modal component that displays product details (image gallery, name, price, description, stock, add-to-cart) in an overlay popup
- Updated the home page and products listing page to open the dialog on product click instead of navigating to `/products/[id]`
- Dialog supports Escape key, backdrop click to close, and locks body scroll while open

## Test plan
- [ ] Click a product on the home page — verify the dialog opens with correct product details
- [ ] Click a product on the `/products` page — verify same dialog behavior
- [ ] Verify image gallery thumbnails work inside the dialog
- [ ] Verify "Add to cart" link works from inside the dialog
- [ ] Verify dialog closes on Escape key, backdrop click, and Close button
- [ ] Verify page scroll is locked while dialog is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)