### PR TITLE
Fix shop CI demo: shorten kind cluster name, add RBAC for shop namespace

### DIFF
--- a/.github/workflows/ci-demo-shop-mirrord-vs-baseline.yml
+++ b/.github/workflows/ci-demo-shop-mirrord-vs-baseline.yml
@@ -39,7 +39,8 @@ jobs:
 
       - name: Create kind cluster
         run: |
-          cat <<EOF | kind create cluster --config=- --name ci-demo-shop-${{ github.sha }}
+          SHORT_SHA="${GITHUB_SHA::8}"
+          cat <<EOF | kind create cluster --config=- --name ci-shop-${SHORT_SHA}
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           nodes:
@@ -124,7 +125,7 @@ jobs:
       - name: Load images into kind
         run: |
           export IMAGE_TAG="ci-demo-${{ github.sha }}"
-          export CLUSTER_NAME="ci-demo-shop-${{ github.sha }}"
+          export CLUSTER_NAME="ci-shop-${GITHUB_SHA::8}"
 
           kind load docker-image order-service:${IMAGE_TAG} --name ${CLUSTER_NAME}
           kind load docker-image inventory-service:${IMAGE_TAG} --name ${CLUSTER_NAME}
@@ -192,7 +193,7 @@ jobs:
       - name: Delete kind cluster
         if: always()
         run: |
-          kind delete cluster --name ci-demo-shop-${{ github.sha }} || true
+          kind delete cluster --name ci-shop-${GITHUB_SHA::8} || true
 
   mirrord-ci:
     name: mirrord CI (GKE - Fast)
@@ -221,7 +222,7 @@ jobs:
           mkdir -p $HOME/.kube
           echo "${{ secrets.KUBECONFIG_BASE64 }}" | base64 -d > $HOME/.kube/config
           chmod 600 $HOME/.kube/config
-          kubectl get ns shop >/dev/null
+          kubectl get deployments -n shop >/dev/null
 
       - name: Build order-service
         working-directory: apps/shop/order-service

--- a/.mirrord/mirrord-ci-shop.json
+++ b/.mirrord/mirrord-ci-shop.json
@@ -1,0 +1,25 @@
+{
+  "target": {
+    "namespace": "shop",
+    "path": {
+      "deployment": "order-service"
+    }
+  },
+  "ci": {
+    "output_dir": "/tmp/mirrord"
+  },
+  "feature": {
+    "network": {
+      "incoming": {
+        "mode": "steal",
+        "http_filter": {
+          "header_filter": "baggage:\\s*[^\\n]*\\bmirrord=mirrord-ci-shop\\b"
+        }
+      },
+      "outgoing": true
+    },
+    "fs": {
+      "mode": "read"
+    }
+  }
+}

--- a/overlays/gke/shop/kustomization.yaml
+++ b/overlays/gke/shop/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - httproute.yaml
   - healthcheckpolicy.yaml
   - mirrord-policy.yaml
+  - mirrord-ci-rbac.yaml

--- a/overlays/gke/shop/mirrord-ci-rbac.yaml
+++ b/overlays/gke/shop/mirrord-ci-rbac.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mirrord-ci
+  namespace: shop
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "deployments/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["mirrord.metalbear.co"]
+    resources: ["mirrordclustersessions"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["queues.mirrord.metalbear.co"]
+    resources: ["mirrordkafkaephemeraltopics", "mirrordsqssessions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policies.mirrord.metalbear.co"]
+    resources: ["mirrordpolicies"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mirrord-ci
+  namespace: shop
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mirrord-ci
+subjects:
+  - kind: ServiceAccount
+    name: mirrord-ci
+    namespace: ip-visit-counter


### PR DESCRIPTION
- Shorten kind cluster name to ci-shop-<8-char-sha> to avoid hostname length limit
- Add Role + RoleBinding granting mirrord-ci SA access to shop namespace
- Add HTTPRoute rules for /orders and /banner
- Use kubectl get deployments instead of kubectl get ns for kubeconfig verification