### PR TITLE
feat(shop): product popup dialog instead of page navigation

### DIFF
--- a/apps/shop/metal-mart-frontend/src/app/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/page.tsx
@@ -6,6 +6,7 @@ import Header from "@/components/Header";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import NewBadge from "@/components/NewBadge";
 import ProductImage from "@/components/ProductImage";
+import ProductModal from "@/components/ProductModal";
 import { getPrimaryImageUrl, type Product } from "@/lib/product";
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
@@ -15,23 +16,25 @@ function ProductTile({
   variant,
   delay = 0,
   elevated = false,
+  onSelect,
 }: {
   product: Product;
   variant: "featured" | "standard" | "wide";
   delay?: number;
   /** Above mascot on home page so card stays opaque */
   elevated?: boolean;
+  onSelect: (id: number) => void;
 }) {
-  const href = `/products/${product.id}`;
   const price = `$${(product.price_cents / 100).toFixed(2)}`;
 
   const elevatedClass = elevated ? "relative z-30" : "";
 
   if (variant === "featured") {
     return (
-      <Link
-        href={href}
-        className={`group relative flex h-full min-h-[280px] flex-col overflow-hidden rounded-2xl border border-slate-300 bg-slate-100 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-[#6a4ff5]/15 hover:border-[#6a4ff5]/30 animate-card-reveal ${elevatedClass}`}
+      <button
+        type="button"
+        onClick={() => onSelect(product.id)}
+        className={`group relative flex h-full min-h-[280px] w-full flex-col overflow-hidden rounded-2xl border border-slate-300 bg-slate-100 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-[#6a4ff5]/15 hover:border-[#6a4ff5]/30 animate-card-reveal text-left ${elevatedClass}`}
         style={{ animationDelay: `${delay}s` }}
       >
         {product.is_new && <NewBadge size="default" />}
@@ -57,18 +60,19 @@ function ProductTile({
           </h2>
           <p className="mt-1 text-lg font-semibold text-white/90">{price}</p>
           <span className="mt-3 inline-block text-sm font-medium text-white/90 underline-offset-2 group-hover:underline">
-            Shop now →
+            Quick view →
           </span>
         </div>
-      </Link>
+      </button>
     );
   }
 
   if (variant === "wide") {
     return (
-      <Link
-        href={href}
-        className={`group relative flex flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal sm:flex-row ${elevatedClass}`}
+      <button
+        type="button"
+        onClick={() => onSelect(product.id)}
+        className={`group relative flex w-full flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal text-left sm:flex-row ${elevatedClass}`}
         style={{ animationDelay: `${delay}s` }}
       >
         {product.is_new && <NewBadge size="default" />}
@@ -98,15 +102,16 @@ function ProductTile({
             </p>
           )}
         </div>
-      </Link>
+      </button>
     );
   }
 
   // standard
   return (
-    <Link
-      href={href}
-      className={`group relative flex flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal ${elevatedClass}`}
+    <button
+      type="button"
+      onClick={() => onSelect(product.id)}
+      className={`group relative flex w-full flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal text-left ${elevatedClass}`}
       style={{ animationDelay: `${delay}s` }}
     >
       {product.is_new && <NewBadge size="default" />}
@@ -131,7 +136,7 @@ function ProductTile({
         </h2>
         <p className="mt-1 font-semibold text-[#6a4ff5]">{price}</p>
       </div>
-    </Link>
+    </button>
   );
 }
 
@@ -139,6 +144,7 @@ export default function Home() {
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedProductId, setSelectedProductId] = useState<number | null>(null);
 
   useEffect(() => {
     fetch(`${basePath}/api/products`)
@@ -207,7 +213,7 @@ export default function Home() {
                           : ""
                       }
                     >
-                      <ProductTile product={featured} variant="featured" delay={0} elevated />
+                      <ProductTile product={featured} variant="featured" delay={0} elevated onSelect={setSelectedProductId} />
                     </div>
                   )}
                   {/* Side tiles - products 2 and 3 stacked on the right (or single tile spans 2 rows) */}
@@ -215,18 +221,18 @@ export default function Home() {
                     <div
                       className={`md:col-span-2 ${rest[1] ? "md:row-span-1" : "md:row-span-2"}`}
                     >
-                      <ProductTile product={rest[0]} variant="standard" delay={0.06} elevated />
+                      <ProductTile product={rest[0]} variant="standard" delay={0.06} elevated onSelect={setSelectedProductId} />
                     </div>
                   )}
                   {rest[1] && (
                     <div className="md:col-span-2 md:row-span-1">
-                      <ProductTile product={rest[1]} variant="standard" delay={0.12} elevated />
+                      <ProductTile product={rest[1]} variant="standard" delay={0.12} elevated onSelect={setSelectedProductId} />
                     </div>
                   )}
                   {/* Bottom row - product 4 as wide horizontal tile */}
                   {rest[2] && (
                     <div className="md:col-span-4">
-                      <ProductTile product={rest[2]} variant="wide" delay={0.18} elevated />
+                      <ProductTile product={rest[2]} variant="wide" delay={0.18} elevated onSelect={setSelectedProductId} />
                     </div>
                   )}
                   {/* Products 5+ in a grid */}
@@ -239,6 +245,7 @@ export default function Home() {
                           variant="standard"
                           delay={0.24 + i * 0.06}
                           elevated
+                          onSelect={setSelectedProductId}
                         />
                       ))}
                     </div>
@@ -268,6 +275,12 @@ export default function Home() {
           </div>
         </section>
       </main>
+      {selectedProductId !== null && (
+        <ProductModal
+          productId={selectedProductId}
+          onClose={() => setSelectedProductId(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/shop/metal-mart-frontend/src/app/products/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import Header from "@/components/Header";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import NewBadge from "@/components/NewBadge";
 import ProductImage from "@/components/ProductImage";
+import ProductModal from "@/components/ProductModal";
 import { getPrimaryImageUrl, type Product } from "@/lib/product";
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
@@ -14,6 +14,7 @@ export default function ProductsPage() {
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedProductId, setSelectedProductId] = useState<number | null>(null);
 
   useEffect(() => {
     fetch(`${basePath}/api/products`)
@@ -56,10 +57,11 @@ export default function ProductsPage() {
           </h1>
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
             {products.map((p, i) => (
-              <Link
+              <button
                 key={p.id}
-                href={`/products/${p.id}`}
-                className="group relative flex flex-col overflow-hidden rounded-xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal"
+                type="button"
+                onClick={() => setSelectedProductId(p.id)}
+                className="group relative flex w-full flex-col overflow-hidden rounded-xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal text-left"
                 style={{ animationDelay: `${i * 0.06}s` }}
               >
                 {p.is_new && <NewBadge size="default" />}
@@ -85,11 +87,17 @@ export default function ProductsPage() {
                   <p className="mt-2 text-lg font-semibold text-[#6a4ff5]">${(p.price_cents / 100).toFixed(2)}</p>
                   <p className="mt-auto pt-3 text-xs text-slate-500">In stock: {p.stock}</p>
                 </div>
-              </Link>
+              </button>
             ))}
           </div>
         </div>
       </main>
+      {selectedProductId !== null && (
+        <ProductModal
+          productId={selectedProductId}
+          onClose={() => setSelectedProductId(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/shop/metal-mart-frontend/src/components/ProductModal.tsx
+++ b/apps/shop/metal-mart-frontend/src/components/ProductModal.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import ProductImage from "@/components/ProductImage";
+import NewBadge from "@/components/NewBadge";
+import { getImageUrls, type Product } from "@/lib/product";
+
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
+export default function ProductModal({
+  productId,
+  onClose,
+}: {
+  productId: number;
+  onClose: () => void;
+}) {
+  const [product, setProduct] = useState<Product | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setSelectedIndex(0);
+    fetch(`${basePath}/api/products/${productId}`)
+      .then((r) => {
+        if (!r.ok) throw new Error("Product not found");
+        return r.json();
+      })
+      .then(setProduct)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [productId]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      document.body.style.overflow = "";
+    };
+  }, [onClose]);
+
+  const imageUrls = product ? getImageUrls(product) : [];
+  const labels = imageUrls.length === 2 ? ["Front", "Back"] : undefined;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="relative w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-2xl bg-white shadow-2xl animate-card-reveal">
+        {/* Close button */}
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-white/80 text-slate-500 shadow backdrop-blur transition-colors hover:bg-white hover:text-slate-900"
+          aria-label="Close"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
+            <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+          </svg>
+        </button>
+
+        {loading && (
+          <div className="flex items-center justify-center p-16">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-[#6a4ff5]" />
+          </div>
+        )}
+
+        {error && (
+          <div className="p-8">
+            <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600">
+              {error}
+            </p>
+          </div>
+        )}
+
+        {product && !loading && (
+          <div className="grid gap-0 sm:grid-cols-2">
+            {/* Image section */}
+            <div className="relative aspect-square overflow-hidden bg-slate-50 sm:rounded-l-2xl">
+              {product.is_new && <NewBadge size="lg" />}
+              {imageUrls.length > 0 ? (
+                <ProductImage
+                  src={imageUrls[selectedIndex]}
+                  alt={labels ? `${product.name} — ${labels[selectedIndex]}` : product.name}
+                  className="h-full w-full object-cover"
+                  fill
+                  sizes="(max-width: 640px) 100vw, 50vw"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-slate-400">
+                  No image
+                </div>
+              )}
+              {imageUrls.length > 1 && (
+                <div className="absolute bottom-3 left-1/2 flex -translate-x-1/2 gap-2">
+                  {imageUrls.map((url, i) => (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => setSelectedIndex(i)}
+                      className={`h-12 w-12 shrink-0 overflow-hidden rounded-lg border-2 transition-colors ${
+                        selectedIndex === i
+                          ? "border-[#6a4ff5] ring-2 ring-[#6a4ff5]/30"
+                          : "border-white/80 hover:border-white"
+                      }`}
+                      aria-label={labels ? labels[i] : `Image ${i + 1}`}
+                    >
+                      <ProductImage
+                        src={url}
+                        alt=""
+                        width={48}
+                        height={48}
+                        className="h-full w-full object-cover"
+                      />
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Details section */}
+            <div className="flex flex-col p-6">
+              <h2 className="text-2xl font-bold tracking-tight text-slate-900">
+                {product.name}
+              </h2>
+              <p className="mt-2 text-xl font-semibold text-[#6a4ff5]">
+                ${(product.price_cents / 100).toFixed(2)}
+              </p>
+              {product.description && (
+                <p className="mt-4 text-sm leading-relaxed text-slate-600">
+                  {product.description}
+                </p>
+              )}
+              <p className="mt-3 text-sm text-slate-500">In stock: {product.stock}</p>
+              <div className="mt-auto flex flex-col gap-3 pt-6">
+                <Link
+                  href={`/cart?add=${product.id}`}
+                  className="btn-primary inline-flex items-center justify-center rounded-xl px-6 py-3 font-semibold focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
+                >
+                  Add to cart
+                </Link>
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="btn-secondary inline-flex items-center justify-center rounded-xl px-6 py-3 font-medium focus:outline-none focus:ring-2 focus:ring-amber-400/40 focus:ring-offset-2"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaced product page navigation with a popup/modal dialog when clicking any product
- The modal shows the product image (with gallery), name, price, description, stock level, and Add to cart button
- Applied to both the home page and the /products listing page
- The product detail page (`/products/[id]`) is preserved but no longer linked from the main UI

## Test plan
- [ ] Click any product on the home page — modal should open with product details
- [ ] Click any product on /products — modal should open
- [ ] Press Escape or click outside the modal to close it
- [ ] Verify "Add to cart" button works from the modal
- [ ] Test on mobile viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)