### PR TITLE
feat(shop): add product dialog popup on products page

### DIFF
--- a/apps/shop/metal-mart-frontend/src/app/globals.css
+++ b/apps/shop/metal-mart-frontend/src/app/globals.css
@@ -109,6 +109,30 @@ a, button {
   opacity: 0.9;
 }
 
+/* Dialog backdrop fade */
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.animate-fade-in {
+  animation: fadeIn 0.2s ease-out forwards;
+}
+
+/* Dialog panel slide up */
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+.animate-slide-up {
+  animation: slideUp 0.25s ease-out forwards;
+}
+
 /* Decorative wave above footer */
 .footer-wave {
   display: block;

--- a/apps/shop/metal-mart-frontend/src/app/products/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import Header from "@/components/Header";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import NewBadge from "@/components/NewBadge";
 import ProductImage from "@/components/ProductImage";
+import ProductDialog from "@/components/ProductDialog";
 import { getPrimaryImageUrl, type Product } from "@/lib/product";
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
@@ -14,6 +14,7 @@ export default function ProductsPage() {
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
 
   useEffect(() => {
     fetch(`${basePath}/api/products`)
@@ -56,10 +57,11 @@ export default function ProductsPage() {
           </h1>
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
             {products.map((p, i) => (
-              <Link
+              <button
                 key={p.id}
-                href={`/products/${p.id}`}
-                className="group relative flex flex-col overflow-hidden rounded-xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal"
+                type="button"
+                onClick={() => setSelectedProduct(p)}
+                className="group relative flex flex-col overflow-hidden rounded-xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal text-left"
                 style={{ animationDelay: `${i * 0.06}s` }}
               >
                 {p.is_new && <NewBadge size="default" />}
@@ -85,11 +87,18 @@ export default function ProductsPage() {
                   <p className="mt-2 text-lg font-semibold text-[#6a4ff5]">${(p.price_cents / 100).toFixed(2)}</p>
                   <p className="mt-auto pt-3 text-xs text-slate-500">In stock: {p.stock}</p>
                 </div>
-              </Link>
+              </button>
             ))}
           </div>
         </div>
       </main>
+
+      {selectedProduct && (
+        <ProductDialog
+          product={selectedProduct}
+          onClose={() => setSelectedProduct(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/shop/metal-mart-frontend/src/components/ProductDialog.tsx
+++ b/apps/shop/metal-mart-frontend/src/components/ProductDialog.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import NewBadge from "@/components/NewBadge";
+import ProductImage from "@/components/ProductImage";
+import { getImageUrls, type Product } from "@/lib/product";
+
+interface ProductDialogProps {
+  product: Product;
+  onClose: () => void;
+}
+
+export default function ProductDialog({ product, onClose }: ProductDialogProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [product.id]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [handleKeyDown]);
+
+  const imageUrls = getImageUrls(product);
+  const labels = imageUrls.length === 2 ? ["Front", "Back"] : undefined;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={product.name}
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 animate-fade-in"
+        onClick={onClose}
+      />
+
+      {/* Dialog panel */}
+      <div className="relative z-10 w-full max-w-3xl max-h-[90vh] overflow-y-auto rounded-2xl border border-slate-200 bg-white shadow-2xl animate-slide-up">
+        {/* Close button */}
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 z-20 flex h-9 w-9 items-center justify-center rounded-full bg-white/80 text-slate-500 shadow backdrop-blur transition-colors hover:bg-white hover:text-slate-900"
+          aria-label="Close"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+
+        <div className="grid gap-6 p-6 sm:grid-cols-2 sm:gap-8 sm:p-8">
+          {/* Image gallery */}
+          <div className="space-y-3">
+            <div className="relative aspect-square overflow-hidden rounded-xl border border-slate-200 bg-slate-50 shadow-lg">
+              {product.is_new && <NewBadge size="lg" />}
+              {imageUrls.length > 0 ? (
+                <ProductImage
+                  src={imageUrls[selectedIndex]}
+                  alt={labels ? `${product.name} — ${labels[selectedIndex]}` : product.name}
+                  className="h-full w-full object-cover"
+                  fill
+                  sizes="(max-width: 640px) 90vw, 40vw"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-slate-400">
+                  No image
+                </div>
+              )}
+            </div>
+            {imageUrls.length > 1 && (
+              <div className="flex gap-2">
+                {imageUrls.map((url, i) => (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={() => setSelectedIndex(i)}
+                    className={`relative h-14 w-14 shrink-0 overflow-hidden rounded-lg border-2 transition-colors ${
+                      selectedIndex === i
+                        ? "border-[#6a4ff5] ring-2 ring-[#6a4ff5]/30"
+                        : "border-slate-200 hover:border-slate-300"
+                    }`}
+                    aria-label={labels ? labels[i] : `Image ${i + 1}`}
+                  >
+                    <ProductImage
+                      src={url}
+                      alt=""
+                      width={56}
+                      height={56}
+                      className="h-full w-full object-cover"
+                    />
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Product details */}
+          <div className="flex flex-col">
+            <h2 className="text-2xl font-bold tracking-tight text-slate-900">
+              {product.name}
+            </h2>
+            <p className="mt-2 text-xl font-semibold text-[#6a4ff5]">
+              ${(product.price_cents / 100).toFixed(2)}
+            </p>
+            {product.description && (
+              <p className="mt-4 text-slate-600 leading-relaxed">
+                {product.description}
+              </p>
+            )}
+            <p className="mt-3 text-sm text-slate-500">In stock: {product.stock}</p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Link
+                href={`/cart?add=${product.id}`}
+                className="btn-primary inline-flex items-center justify-center rounded-xl px-7 py-3 font-semibold focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
+              >
+                Add to cart
+              </Link>
+              <button
+                type="button"
+                onClick={onClose}
+                className="btn-secondary inline-flex items-center justify-center rounded-xl px-5 py-3 font-medium focus:outline-none focus:ring-2 focus:ring-amber-400/40 focus:ring-offset-2"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **New `ProductDialog` component** — modal overlay with image gallery (front/back toggle), product description, price, stock info, and an "Add to cart" button
- **Updated `/products` page** — clicking a product tile now opens the dialog inline instead of navigating to `/products/[id]`
- **Added dialog animations** — smooth `fadeIn` backdrop and `slideUp` panel entrance in `globals.css`

The dialog supports keyboard dismiss (Escape), click-outside-to-close, scroll lock while open, and is fully accessible (`role="dialog"`, `aria-modal`).

## Test plan

- [ ] Navigate to `/products` and click a product tile — dialog should appear with product details
- [ ] Verify image gallery thumbnails toggle between front/back images
- [ ] Click "Add to cart" in the dialog — should navigate to cart with the product added
- [ ] Press Escape or click the backdrop — dialog should close
- [ ] Confirm the close button (X) in the top-right corner works
- [ ] Verify the page behind the dialog does not scroll while the dialog is open
- [ ] Test on mobile viewport — dialog should be responsive

https://claude.ai/code/session_013LJXFRo7A4PdPgcbA9Dk7n