### PR TITLE
Rename "products" to "swag" in shop UI

### DIFF
--- a/apps/shop/metal-mart-frontend/src/app/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/page.tsx
@@ -185,7 +185,7 @@ export default function Home() {
           <div className="mx-auto max-w-6xl">
             {hasProducts && (
               <h1 className="hand-drawn-underline mb-10 inline-block text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl md:text-5xl">
-                Featured products
+                Featured swag
               </h1>
             )}
             {hasProducts ? (
@@ -250,18 +250,18 @@ export default function Home() {
                     href="/products"
                     className="text-sm font-medium text-[#6a4ff5] hover:text-[#5a3fe5] hover:underline"
                   >
-                    View all products →
+                    View all swag →
                   </Link>
                 </div>
               </>
             ) : (
               <div className="rounded-2xl border border-slate-300 bg-slate-50 px-8 py-16 text-center">
-                <p className="text-slate-600">No products yet.</p>
+                <p className="text-slate-600">No swag yet.</p>
                 <Link
                   href="/products"
                   className="btn-primary mt-4 inline-block rounded-xl px-6 py-2.5 text-sm font-medium"
                 >
-                  Browse products
+                  Browse swag
                 </Link>
               </div>
             )}

--- a/apps/shop/metal-mart-frontend/src/app/products/[id]/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/[id]/page.tsx
@@ -57,7 +57,7 @@ export default function ProductDetailPage() {
             href="/products"
             className="mt-4 inline-block text-[#6a4ff5] hover:text-[#5a3fe5]"
           >
-            ← Back to products
+            ← Back to swag
           </Link>
         </main>
       </div>
@@ -136,7 +136,7 @@ export default function ProductDetailPage() {
                   href="/products"
                   className="btn-secondary inline-flex items-center justify-center rounded-xl px-6 py-3 font-medium focus:outline-none focus:ring-2 focus:ring-amber-400/40 focus:ring-offset-2"
                 >
-                  ← Back to products
+                  ← Back to swag
                 </Link>
               </div>
             </div>

--- a/apps/shop/metal-mart-frontend/src/app/products/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/page.tsx
@@ -52,7 +52,7 @@ export default function ProductsPage() {
       <main className="flex-1 px-6 py-8">
         <div className="mx-auto max-w-6xl">
           <h1 className="hand-drawn-underline mb-10 inline-block text-2xl font-bold tracking-tight text-slate-900">
-            Products
+            Swag
           </h1>
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
             {products.map((p, i) => (

--- a/apps/shop/metal-mart-frontend/src/components/Header.tsx
+++ b/apps/shop/metal-mart-frontend/src/components/Header.tsx
@@ -40,7 +40,7 @@ export default function Header({ showSubtitle = false }: HeaderProps) {
               href="/products"
               className="text-sm font-medium text-slate-600 hover:text-slate-900"
             >
-              Products
+              Swag
             </Link>
             <Link
               href="/cart"


### PR DESCRIPTION
## Summary
- Renamed all user-facing references from "products" to "swag" across the MetalMart shop frontend
- Updated headings ("Featured products" → "Featured swag", "Products" → "Swag")
- Updated navigation link in header ("Products" → "Swag")
- Updated back-navigation buttons ("← Back to products" → "← Back to swag")
- Updated empty-state text ("No products yet." → "No swag yet.", "Browse products" → "Browse swag", "View all products →" → "View all swag →")

## Changed files
- `src/app/page.tsx` — Home page heading, "View all" link, empty-state messages
- `src/app/products/page.tsx` — Products listing page heading
- `src/app/products/[id]/page.tsx` — Product detail back-navigation (2 instances)
- `src/components/Header.tsx` — Nav link text

## Test plan
- [ ] Visit home page — verify heading says "Featured swag"
- [ ] Visit home page — verify "View all swag →" link at the bottom
- [ ] Visit `/products` — verify heading says "Swag"
- [ ] Visit a product detail page — verify back button says "← Back to swag"
- [ ] Visit product detail error state — verify back link says "← Back to swag"
- [ ] Check header nav — verify link says "Swag" instead of "Products"
- [ ] Verify no regressions in routing (links still go to `/products` routes)

https://claude.ai/code/session_01SYNSRpz7p5wLBTFiCG1Cya