### PR TITLE
Rename home page heading to "Featured Swag"

### DIFF
--- a/apps/shop/metal-mart-frontend/src/app/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/page.tsx
@@ -185,7 +185,7 @@ export default function Home() {
           <div className="mx-auto max-w-6xl">
             {hasProducts && (
               <h1 className="hand-drawn-underline mb-10 inline-block text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl md:text-5xl">
-                Featured products
+                Featured Swag
               </h1>
             )}
             {hasProducts ? (


### PR DESCRIPTION
## Summary
- Changes the heading text on the home page from "Featured products" to "Featured Swag"
- Text-only change in `apps/shop/metal-mart-frontend/src/app/page.tsx`

## Test plan
- [ ] Verify the home page heading displays "Featured Swag"
- [ ] Confirm no other text or layout is affected

https://claude.ai/code/session_01WJ39wX3XpGnGaojtL1HLGW