### PR TITLE
Only run shop preview workflow for demo- branches

### DIFF
--- a/.github/workflows/preview-shop-pr.yml
+++ b/.github/workflows/preview-shop-pr.yml
@@ -20,7 +20,7 @@ jobs:
   # ─── Job 1: Detect which services changed ───
   detect-changes:
     name: Detect changed services
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && startsWith(github.head_ref, 'demo-')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
@@ -252,7 +252,7 @@ jobs:
   # ─── Job 4: Stop all previews on merge/close ───
   preview-stop:
     name: Stop all previews on merge/close
-    if: github.event.action == 'closed'
+    if: github.event.action == 'closed' && startsWith(github.head_ref, 'demo-')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
Adds startsWith(github.head_ref, 'demo-') gate to both the detect-changes and preview-stop jobs so the workflow is skipped entirely for PRs from non-demo branches.