### PR TITLE
Add suggested products section to product detail page

### DIFF
--- a/apps/shop/metal-mart-frontend/src/app/products/[id]/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/[id]/page.tsx
@@ -7,6 +7,7 @@ import Header from "@/components/Header";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import NewBadge from "@/components/NewBadge";
 import ProductImage from "@/components/ProductImage";
+import SuggestedProducts from "@/components/SuggestedProducts";
 import { getImageUrls, type Product } from "@/lib/product";
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
@@ -141,6 +142,7 @@ export default function ProductDetailPage() {
               </div>
             </div>
           </div>
+          <SuggestedProducts currentProductId={product.id} />
         </div>
       </main>
     </div>

--- a/apps/shop/metal-mart-frontend/src/components/SuggestedProducts.tsx
+++ b/apps/shop/metal-mart-frontend/src/components/SuggestedProducts.tsx
@@ -7,57 +7,66 @@ import { getPrimaryImageUrl, type Product } from "@/lib/product";
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
 
-export default function SuggestedProducts({ currentProductId }: { currentProductId: number }) {
+type SuggestedProductsProps = {
+  currentProductId: number;
+};
+
+export default function SuggestedProducts({ currentProductId }: SuggestedProductsProps) {
   const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     fetch(`${basePath}/api/products`)
       .then((r) => r.json())
-      .then((all: Product[]) => setProducts(all.filter((p) => p.id !== currentProductId)))
-      .catch(() => setProducts([]));
+      .then((all: Product[]) => {
+        const others = all.filter((p) => p.id !== currentProductId);
+        // Shuffle and pick up to 6 suggestions
+        const shuffled = others.sort(() => Math.random() - 0.5);
+        setProducts(shuffled.slice(0, 6));
+      })
+      .catch(() => setProducts([]))
+      .finally(() => setLoading(false));
   }, [currentProductId]);
 
-  if (products.length === 0) return null;
+  if (loading || products.length === 0) return null;
 
   return (
     <section className="mt-16">
       <h2 className="hand-drawn-underline mb-6 inline-block text-xl font-bold tracking-tight text-slate-900">
         You might also like
       </h2>
-      <div className="relative">
-        <div className="flex gap-4 overflow-x-auto pb-4 scrollbar-thin">
-          {products.map((p) => (
-            <Link
-              key={p.id}
-              href={`/products/${p.id}`}
-              className="group flex w-48 shrink-0 flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-lg hover:shadow-[#6a4ff5]/10"
-            >
-              <div className="relative aspect-square overflow-hidden bg-slate-100">
-                {getPrimaryImageUrl(p) ? (
-                  <ProductImage
-                    src={getPrimaryImageUrl(p)!}
-                    alt={p.name}
-                    className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-                    fill
-                    sizes="192px"
-                  />
-                ) : (
-                  <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
-                    No image
-                  </div>
-                )}
-              </div>
-              <div className="flex flex-1 flex-col p-3">
-                <h3 className="text-sm font-semibold text-slate-900 group-hover:text-[#6a4ff5] transition-colors line-clamp-2">
-                  {p.name}
-                </h3>
-                <p className="mt-1 text-sm font-semibold text-[#6a4ff5]">
-                  ${(p.price_cents / 100).toFixed(2)}
-                </p>
-              </div>
-            </Link>
-          ))}
-        </div>
+      <div className="flex gap-4 overflow-x-auto pb-4 scrollbar-thin">
+        {products.map((p) => (
+          <Link
+            key={p.id}
+            href={`/products/${p.id}`}
+            className="group flex w-44 shrink-0 flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-lg hover:shadow-[#6a4ff5]/10"
+          >
+            <div className="relative aspect-square overflow-hidden bg-slate-100">
+              {getPrimaryImageUrl(p) ? (
+                <ProductImage
+                  src={getPrimaryImageUrl(p)!}
+                  alt={p.name}
+                  className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                  fill
+                  sizes="176px"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-xs text-slate-400">
+                  No image
+                </div>
+              )}
+            </div>
+            <div className="flex flex-1 flex-col p-3">
+              <h3 className="text-sm font-semibold text-slate-900 leading-snug group-hover:text-[#6a4ff5] transition-colors line-clamp-2">
+                {p.name}
+              </h3>
+              <p className="mt-1.5 text-sm font-semibold text-[#6a4ff5]">
+                ${(p.price_cents / 100).toFixed(2)}
+              </p>
+            </div>
+          </Link>
+        ))}
       </div>
     </section>
   );

--- a/apps/shop/metal-mart-frontend/src/components/SuggestedProducts.tsx
+++ b/apps/shop/metal-mart-frontend/src/components/SuggestedProducts.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import ProductImage from "@/components/ProductImage";
+import { getPrimaryImageUrl, type Product } from "@/lib/product";
+
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
+export default function SuggestedProducts({ currentProductId }: { currentProductId: number }) {
+  const [products, setProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    fetch(`${basePath}/api/products`)
+      .then((r) => r.json())
+      .then((all: Product[]) => setProducts(all.filter((p) => p.id !== currentProductId)))
+      .catch(() => setProducts([]));
+  }, [currentProductId]);
+
+  if (products.length === 0) return null;
+
+  return (
+    <section className="mt-16">
+      <h2 className="hand-drawn-underline mb-6 inline-block text-xl font-bold tracking-tight text-slate-900">
+        You might also like
+      </h2>
+      <div className="relative">
+        <div className="flex gap-4 overflow-x-auto pb-4 scrollbar-thin">
+          {products.map((p) => (
+            <Link
+              key={p.id}
+              href={`/products/${p.id}`}
+              className="group flex w-48 shrink-0 flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-lg hover:shadow-[#6a4ff5]/10"
+            >
+              <div className="relative aspect-square overflow-hidden bg-slate-100">
+                {getPrimaryImageUrl(p) ? (
+                  <ProductImage
+                    src={getPrimaryImageUrl(p)!}
+                    alt={p.name}
+                    className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                    fill
+                    sizes="192px"
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
+                    No image
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-1 flex-col p-3">
+                <h3 className="text-sm font-semibold text-slate-900 group-hover:text-[#6a4ff5] transition-colors line-clamp-2">
+                  {p.name}
+                </h3>
+                <p className="mt-1 text-sm font-semibold text-[#6a4ff5]">
+                  ${(p.price_cents / 100).toFixed(2)}
+                </p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a "You might also like" section below the product details on the product detail page
- Displays up to 6 randomly shuffled product cards in a horizontal scrollable row
- Each card shows the product image, name, and price, and links to that product's detail page
- Styled consistently with the existing MetalMart design system (purple accents, hover effects, rounded cards)

Inspired by Amazon's "Top rated similar items" section.

## Test plan

- [ ] Open any product detail page and verify the "You might also like" section appears below the product info
- [ ] Confirm the section shows up to 6 products (excluding the currently viewed product)
- [ ] Click a suggested product card and verify it navigates to that product's detail page
- [ ] Verify the row is horizontally scrollable when there are more cards than fit the viewport
- [ ] Test on mobile viewport to confirm responsive behavior
- [ ] Refresh the page and verify the suggestions are shuffled (different order)

https://claude.ai/code/session_01H7z5NY2AR37DnaQ8GM8ZWG