### PR TITLE
Update home page heading to Test

### DIFF
--- a/apps/shop/metal-mart-frontend/src/app/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/page.tsx
@@ -185,7 +185,7 @@ export default function Home() {
           <div className="mx-auto max-w-6xl">
             {hasProducts && (
               <h1 className="hand-drawn-underline mb-10 inline-block text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl md:text-5xl">
-                Featured products
+                Test
               </h1>
             )}
             {hasProducts ? (


### PR DESCRIPTION
## Summary
- Changed the home page heading from "Featured products" to "Test" in the MetalMart frontend

## Test plan
- [ ] Navigate to the home page and verify the heading reads "Test"

🤖 Generated with [Claude Code](https://claude.com/claude-code)