### PR TITLE
feat(shop): gift wrap option (+$4.99) at checkout [SOL-142]

### DIFF
--- a/apps/shop/delivery-service/src/index.ts
+++ b/apps/shop/delivery-service/src/index.ts
@@ -26,6 +26,9 @@ async function initDb() {
         created_at TIMESTAMPTZ DEFAULT NOW()
       )
     `);
+    await client.query(`
+      ALTER TABLE deliveries ADD COLUMN IF NOT EXISTS gift_wrap BOOLEAN NOT NULL DEFAULT FALSE
+    `);
   } finally {
     client.release();
   }
@@ -62,11 +65,15 @@ async function startConsumer() {
         });
         const body = JSON.parse(message.value?.toString() || "{}");
         const orderId = body.orderId;
-        console.log(`[${t}] Received order ${orderId}`);
+        const giftWrap = body.gift_wrap === true;
+        console.log(`[${t}] Received order ${orderId} (gift_wrap=${giftWrap})`);
 
         const client = await pool.connect();
         try {
-          await client.query("INSERT INTO deliveries (order_id, status) VALUES ($1, 'processing')", [orderId]);
+          await client.query(
+            "INSERT INTO deliveries (order_id, status, gift_wrap) VALUES ($1, 'processing', $2)",
+            [orderId, giftWrap]
+          );
         } finally {
           client.release();
         }
@@ -88,7 +95,7 @@ app.get("/health", (_req, res) => {
 app.get("/deliveries", async (_req, res) => {
   try {
     const { rows } = await pool.query(
-      "SELECT id, order_id, status, created_at FROM deliveries ORDER BY created_at DESC LIMIT 50"
+      "SELECT id, order_id, status, gift_wrap, created_at FROM deliveries ORDER BY created_at DESC LIMIT 50"
     );
     res.json(rows);
   } catch (err) {
@@ -102,7 +109,7 @@ app.get("/deliveries/order/:orderId", async (req, res) => {
   if (isNaN(orderId)) return res.status(400).json({ error: "Invalid order ID" });
   try {
     const { rows } = await pool.query(
-      "SELECT id, order_id, status, created_at FROM deliveries WHERE order_id = $1",
+      "SELECT id, order_id, status, gift_wrap, created_at FROM deliveries WHERE order_id = $1",
       [orderId]
     );
     res.json(rows[0] || null);

--- a/apps/shop/delivery-service/src/index.ts
+++ b/apps/shop/delivery-service/src/index.ts
@@ -109,7 +109,7 @@ app.get("/deliveries/order/:orderId", async (req, res) => {
   if (isNaN(orderId)) return res.status(400).json({ error: "Invalid order ID" });
   try {
     const { rows } = await pool.query(
-      "SELECT id, order_id, status, gift_wrap, created_at FROM deliveries WHERE order_id = $1",
+      "SELECT id, order_id, status, gift_wrap, created_at FROM deliveries WHERE order_id = $1 ORDER BY created_at DESC LIMIT 1",
       [orderId]
     );
     res.json(rows[0] || null);

--- a/apps/shop/metal-mart-frontend/src/app/checkout/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/checkout/page.tsx
@@ -15,6 +15,8 @@ type Product = {
   image_urls?: string[] | null;
 };
 
+const GIFT_WRAP_FEE_CENTS = 499;
+
 export default function CheckoutPage() {
   const [cart, setCart] = useState<{ productId: number; quantity: number; product?: Product }[]>([]);
   const [loading, setLoading] = useState(true);
@@ -22,6 +24,7 @@ export default function CheckoutPage() {
   const [orderId, setOrderId] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [email, setEmail] = useState("");
+  const [giftWrap, setGiftWrap] = useState(false);
 
   useEffect(() => {
     const raw = localStorage.getItem("metal-mart-cart");
@@ -35,7 +38,9 @@ export default function CheckoutPage() {
     ).then(setCart).finally(() => setLoading(false));
   }, []);
 
-  const totalCents = cart.reduce((s, i) => s + (i.product?.price_cents ?? 0) * i.quantity, 0);
+  const subtotalCents = cart.reduce((s, i) => s + (i.product?.price_cents ?? 0) * i.quantity, 0);
+  const giftWrapFeeCents = giftWrap ? GIFT_WRAP_FEE_CENTS : 0;
+  const totalCents = subtotalCents + giftWrapFeeCents;
   const orderItems = cart.map(({ productId, quantity }) => ({ productId, quantity }));
 
   const handleSubmit = async () => {
@@ -45,7 +50,12 @@ export default function CheckoutPage() {
       const r = await fetch(`${basePath}/api/orders`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ items: orderItems, total_cents: totalCents, ...(email ? { customer_email: email } : {}) }),
+        body: JSON.stringify({
+          items: orderItems,
+          total_cents: subtotalCents,
+          gift_wrap: giftWrap,
+          ...(email ? { customer_email: email } : {}),
+        }),
       });
       const data = await r.json();
       if (r.ok) {
@@ -139,8 +149,35 @@ export default function CheckoutPage() {
                 </span>
               </li>
             ))}
+            {giftWrap && (
+              <li
+                data-testid="gift-wrap-line"
+                className="flex items-center justify-between border-t border-slate-200 pt-3"
+              >
+                <span className="text-slate-700">🎁 Gift wrap</span>
+                <span className="font-semibold text-[#6a4ff5]">
+                  ${(giftWrapFeeCents / 100).toFixed(2)}
+                </span>
+              </li>
+            )}
           </ul>
-          <p className="mb-6 text-xl font-semibold text-slate-900">
+          <label className="mb-6 flex cursor-pointer items-start gap-3 rounded-xl border border-slate-300 bg-slate-50 p-4">
+            <input
+              type="checkbox"
+              checked={giftWrap}
+              onChange={(e) => setGiftWrap(e.target.checked)}
+              data-testid="gift-wrap-checkbox"
+              className="mt-1 h-5 w-5 cursor-pointer rounded border-slate-300 text-[#6a4ff5] focus:ring-2 focus:ring-[#6a4ff5]/40"
+            />
+            <span className="text-slate-700">
+              <span className="font-semibold">🎁 Gift wrap this order</span>{" "}
+              <span className="text-slate-500">(+$4.99)</span>
+            </span>
+          </label>
+          <p
+            data-testid="checkout-total"
+            className="mb-6 text-xl font-semibold text-slate-900"
+          >
             Total: ${(totalCents / 100).toFixed(2)}
           </p>
           <div className="mb-6">

--- a/apps/shop/metal-mart-frontend/src/app/orders/[id]/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/orders/[id]/page.tsx
@@ -15,14 +15,17 @@ type Order = {
   total_cents: number;
   status: string;
   created_at: string;
+  gift_wrap?: boolean;
+  gift_wrap_fee_cents?: number;
 };
 type Product = { id: number; name: string; price_cents: number };
+type Delivery = { status: string; gift_wrap?: boolean };
 
 export default function OrderPage() {
   const params = useParams();
   const id = params?.id as string;
   const [order, setOrder] = useState<Order | null>(null);
-  const [delivery, setDelivery] = useState<{ status: string } | null>(null);
+  const [delivery, setDelivery] = useState<Delivery | null>(null);
   const [lineItems, setLineItems] = useState<{ product: Product; quantity: number }[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -102,6 +105,14 @@ export default function OrderPage() {
                 {delivery && (
                   <p className="text-slate-600">Delivery: {delivery.status}</p>
                 )}
+                {(order.gift_wrap || delivery?.gift_wrap) && (
+                  <p
+                    data-testid="gift-wrap-indicator"
+                    className="inline-flex items-center gap-1.5 rounded-full bg-[#6a4ff5]/10 px-3 py-1 text-sm font-medium text-[#6a4ff5]"
+                  >
+                    🎁 Gift wrapped
+                  </p>
+                )}
               </div>
               {lineItems.length > 0 && (
                 <div>
@@ -118,6 +129,14 @@ export default function OrderPage() {
                         </span>
                       </li>
                     ))}
+                    {order.gift_wrap && (
+                      <li className="flex justify-between border-t border-slate-200 pt-3 text-slate-700">
+                        <span>🎁 Gift wrap</span>
+                        <span className="font-semibold text-[#6a4ff5]">
+                          ${((order.gift_wrap_fee_cents ?? 0) / 100).toFixed(2)}
+                        </span>
+                      </li>
+                    )}
                   </ul>
                   <p className="mt-3 text-lg font-semibold text-slate-900">
                     Total: ${(order.total_cents / 100).toFixed(2)}

--- a/apps/shop/order-service/src/activities.ts
+++ b/apps/shop/order-service/src/activities.ts
@@ -7,8 +7,11 @@ export type CheckoutInput = {
   items: Array<{ productId: number; quantity: number }>;
   total_cents: number;
   customer_email?: string;
+  gift_wrap?: boolean;
   baggage?: string;
 };
+
+const GIFT_WRAP_FEE_CENTS = 499;
 
 export type CheckoutResult = {
   orderId: number;
@@ -74,13 +77,16 @@ export async function chargePayment(input: CheckoutInput & { orderId?: number })
 
 /** Insert order into DB and return orderId */
 export async function createOrder(input: CheckoutInput): Promise<number> {
+  const giftWrap = !!input.gift_wrap;
+  const giftWrapFee = giftWrap ? GIFT_WRAP_FEE_CENTS : 0;
+  const totalCents = input.total_cents + giftWrapFee;
   const client = await pool.connect();
   try {
     const {
       rows: [row],
     } = await client.query(
-      "INSERT INTO orders (items, total_cents, status, customer_email) VALUES ($1, $2, 'confirmed', $3) RETURNING id",
-      [JSON.stringify(input.items), input.total_cents, input.customer_email ?? null]
+      "INSERT INTO orders (items, total_cents, status, customer_email, gift_wrap, gift_wrap_fee_cents) VALUES ($1, $2, 'confirmed', $3, $4, $5) RETURNING id",
+      [JSON.stringify(input.items), totalCents, input.customer_email ?? null, giftWrap, giftWrapFee]
     );
     return row.id as number;
   } finally {
@@ -93,12 +99,14 @@ export async function publishOrderToKafka(input: {
   orderId: number;
   items: Array<{ productId: number; quantity: number }>;
   status: string;
+  gift_wrap?: boolean;
   baggage?: string;
 }): Promise<void> {
   await sendOrderToKafka({
     orderId: input.orderId,
     items: input.items,
     status: input.status,
+    gift_wrap: !!input.gift_wrap,
     baggage: input.baggage,
   });
 }

--- a/apps/shop/order-service/src/index.ts
+++ b/apps/shop/order-service/src/index.ts
@@ -43,6 +43,12 @@ async function initDb() {
     await client.query(`
       ALTER TABLE orders ADD COLUMN IF NOT EXISTS customer_email VARCHAR(255)
     `);
+    await client.query(`
+      ALTER TABLE orders ADD COLUMN IF NOT EXISTS gift_wrap BOOLEAN NOT NULL DEFAULT FALSE
+    `);
+    await client.query(`
+      ALTER TABLE orders ADD COLUMN IF NOT EXISTS gift_wrap_fee_cents INTEGER NOT NULL DEFAULT 0
+    `);
   } finally {
     client.release();
   }
@@ -83,8 +89,11 @@ type OrderInput = {
   items: Array<{ productId: number; quantity: number }>;
   total_cents: number;
   customer_email?: string;
+  gift_wrap?: boolean;
   baggage?: string;
 };
+
+const GIFT_WRAP_FEE_CENTS = 499;
 
 const MAX_PRODUCT_ID = 2 ** 31 - 1; // safe integer, prevents URL injection
 
@@ -161,7 +170,9 @@ async function createOrderViaTemporal(
 async function createOrderDirect(
   input: OrderInput
 ): Promise<{ orderId: number; status: string }> {
-  const { items, total_cents: totalCents, customer_email, baggage } = input;
+  const { items, total_cents: subtotalCents, customer_email, gift_wrap, baggage } = input;
+  const giftWrapFee = gift_wrap ? GIFT_WRAP_FEE_CENTS : 0;
+  const totalCents = subtotalCents + giftWrapFee;
 
   for (const item of items) {
     const productId = encodeURIComponent(String(item.productId));
@@ -211,8 +222,8 @@ async function createOrderDirect(
     const {
       rows: [row],
     } = await client.query(
-      "INSERT INTO orders (items, total_cents, status, customer_email) VALUES ($1, $2, 'confirmed', $3) RETURNING id",
-      [JSON.stringify(items), totalCents, customer_email ?? null]
+      "INSERT INTO orders (items, total_cents, status, customer_email, gift_wrap, gift_wrap_fee_cents) VALUES ($1, $2, 'confirmed', $3, $4, $5) RETURNING id",
+      [JSON.stringify(items), totalCents, customer_email ?? null, !!gift_wrap, giftWrapFee]
     );
     orderId = row.id;
   } finally {
@@ -243,6 +254,7 @@ async function createOrderDirect(
     orderId,
     items,
     status: "confirmed",
+    gift_wrap: !!gift_wrap,
     baggage,
   });
 
@@ -260,10 +272,11 @@ async function createOrderDirect(
 
 app.post("/orders", async (req, res) => {
   const baggage = req.headers["baggage"] as string | undefined;
-  const body = req.body as { items?: unknown; total_cents?: number; customer_email?: string };
+  const body = req.body as { items?: unknown; total_cents?: number; customer_email?: string; gift_wrap?: unknown };
   const total_cents = typeof body.total_cents === "number" ? body.total_cents : 0;
   const customer_email = typeof body.customer_email === "string" ? body.customer_email : undefined;
-  console.log("Order request:", JSON.stringify({ baggage, total_cents, customer_email, items: body.items }, null, 2));
+  const gift_wrap = body.gift_wrap === true;
+  console.log("Order request:", JSON.stringify({ baggage, total_cents, customer_email, gift_wrap, items: body.items }, null, 2));
 
   const validated = validateOrderItems(body.items);
   if ("error" in validated) {
@@ -275,7 +288,7 @@ app.post("/orders", async (req, res) => {
   }
   const { items } = validated;
 
-  const input: OrderInput = { items, total_cents, customer_email, baggage };
+  const input: OrderInput = { items, total_cents, customer_email, gift_wrap, baggage };
 
   try {
     const result =
@@ -306,7 +319,7 @@ app.get("/orders/:id", orderReadLimiter, async (req, res) => {
   if (isNaN(id)) return res.status(400).json({ error: "Invalid order ID" });
   try {
     const { rows } = await pool.query(
-      "SELECT id, items, total_cents, status, created_at FROM orders WHERE id = $1",
+      "SELECT id, items, total_cents, status, created_at, gift_wrap, gift_wrap_fee_cents FROM orders WHERE id = $1",
       [id]
     );
     if (rows.length === 0)

--- a/apps/shop/order-service/src/kafka.ts
+++ b/apps/shop/order-service/src/kafka.ts
@@ -4,6 +4,7 @@ export type SendOrderPayload = {
   orderId: number;
   items: Array<{ productId: number; quantity: number }>;
   status: string;
+  gift_wrap?: boolean;
   baggage?: string;
 };
 
@@ -12,11 +13,12 @@ export type SendOrderPayload = {
  * Used by both the current implementation and the Temporal publishOrderToKafka activity.
  */
 export async function sendOrderToKafka(payload: SendOrderPayload): Promise<void> {
-  const { orderId, items, status, baggage } = payload;
+  const { orderId, items, status, gift_wrap, baggage } = payload;
   const message = {
     orderId,
     items,
     status,
+    gift_wrap: !!gift_wrap,
     timestamp: new Date().toISOString(),
   };
   const kafkaHeaders: Record<string, string> = {};

--- a/apps/shop/order-service/src/workflows/checkout.ts
+++ b/apps/shop/order-service/src/workflows/checkout.ts
@@ -15,6 +15,7 @@ export type CheckoutInput = {
   items: Array<{ productId: number; quantity: number }>;
   total_cents: number;
   customer_email?: string;
+  gift_wrap?: boolean;
   baggage?: string;
 };
 
@@ -34,6 +35,7 @@ export async function CheckoutWorkflow(
     orderId,
     items: input.items,
     status: "confirmed",
+    gift_wrap: !!input.gift_wrap,
     baggage: input.baggage,
   });
   await publishOrderNotificationActivity({


### PR DESCRIPTION
## Summary

Implements SOL-142: customer-facing gift-wrap option that flows end-to-end through frontend, order-service (with DB migration), and delivery-service.

- **Frontend**
  - `/checkout`: 🎁 Gift wrap this order (+\$4.99) checkbox; line item + total update live.
  - `/orders/[id]`: "🎁 Gift wrapped" pill indicator and a fee line item when the order was wrapped.
- **order-service**
  - `POST /orders` accepts `gift_wrap: bool`; server adds 499 cents to total when true (clients send the cart subtotal).
  - Persists `gift_wrap` and `gift_wrap_fee_cents`; returns both on `GET /orders/:id`.
  - Adds `gift_wrap` to the Kafka order event so delivery-service can mirror it.
- **order-db migration**: `ALTER TABLE orders ADD COLUMN IF NOT EXISTS gift_wrap BOOLEAN NOT NULL DEFAULT FALSE` + `gift_wrap_fee_cents INT NOT NULL DEFAULT 0`. Applied at `initDb()`; safe on existing rows.
- **delivery-service**: persists `gift_wrap` and exposes it on `/deliveries/order/:orderId`.

Linear: https://linear.app/metalbear/issue/SOL-142/gift-wrap-feature-demo

## Test plan

- [ ] Preview build passes
- [ ] `/checkout` shows the gift-wrap checkbox; toggling adds \$4.99 to the displayed total
- [ ] `POST /api/orders` with `gift_wrap: true` returns 201 and the order has `gift_wrap=true, gift_wrap_fee_cents=499, total_cents = subtotal + 499`
- [ ] `POST /api/orders` without `gift_wrap` (or `false`) → `gift_wrap=false, gift_wrap_fee_cents=0` (regression)
- [ ] `/orders/<id>` shows "🎁 Gift wrapped" only for wrapped orders
- [ ] `GET /api/deliveries/order/<id>` returns `gift_wrap=true` for wrapped order

🤖 Generated with [Claude Code](https://claude.com/claude-code)