### PR TITLE
Add gift wrap demo flow

### DIFF
--- a/apps/shop/delivery-service/src/index.ts
+++ b/apps/shop/delivery-service/src/index.ts
@@ -82,9 +82,10 @@ async function startConsumer() {
   });
 }
 
-async function fetchGiftWrap(orderId: number): Promise<boolean | null> {
+async function fetchGiftWrap(orderId: number, baggage?: string): Promise<boolean | null> {
   try {
-    const res = await fetch(`${orderServiceUrl}/orders/${orderId}`);
+    const headers = baggage ? { baggage } : undefined;
+    const res = await fetch(`${orderServiceUrl}/orders/${orderId}`, { headers });
     if (!res.ok) {
       console.warn(`Failed to fetch order ${orderId} for delivery response: ${res.status}`);
       return null;
@@ -125,7 +126,8 @@ app.get("/deliveries/order/:orderId", async (req, res) => {
     );
     const delivery = rows[0] || null;
     if (!delivery) return res.json(null);
-    const giftWrap = await fetchGiftWrap(orderId);
+    const baggage = typeof req.headers.baggage === "string" ? req.headers.baggage : undefined;
+    const giftWrap = await fetchGiftWrap(orderId, baggage);
     res.json({ ...delivery, gift_wrap: giftWrap });
   } catch (err) {
     console.error("Error fetching delivery:", err);

--- a/apps/shop/delivery-service/src/index.ts
+++ b/apps/shop/delivery-service/src/index.ts
@@ -14,6 +14,9 @@ const kafka = new Kafka({
   clientId: "delivery-service",
   brokers: (process.env.KAFKA_ADDRESS || "localhost:9092").split(","),
 });
+const orderServiceUrl =
+  process.env.ORDER_SERVICE_URL ||
+  (process.env.KUBERNETES_SERVICE_HOST ? "http://order-service:80" : "http://localhost:3001");
 
 async function initDb() {
   const client = await pool.connect();
@@ -79,6 +82,21 @@ async function startConsumer() {
   });
 }
 
+async function fetchGiftWrap(orderId: number): Promise<boolean | null> {
+  try {
+    const res = await fetch(`${orderServiceUrl}/orders/${orderId}`);
+    if (!res.ok) {
+      console.warn(`Failed to fetch order ${orderId} for delivery response: ${res.status}`);
+      return null;
+    }
+    const order = await res.json() as { gift_wrap?: unknown };
+    return typeof order.gift_wrap === "boolean" ? order.gift_wrap : null;
+  } catch (err) {
+    console.warn(`Failed to fetch order ${orderId} for delivery response:`, err);
+    return null;
+  }
+}
+
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
@@ -102,10 +120,13 @@ app.get("/deliveries/order/:orderId", async (req, res) => {
   if (isNaN(orderId)) return res.status(400).json({ error: "Invalid order ID" });
   try {
     const { rows } = await pool.query(
-      "SELECT id, order_id, status, created_at FROM deliveries WHERE order_id = $1",
+      "SELECT id, order_id, status, created_at FROM deliveries WHERE order_id = $1 ORDER BY created_at DESC LIMIT 1",
       [orderId]
     );
-    res.json(rows[0] || null);
+    const delivery = rows[0] || null;
+    if (!delivery) return res.json(null);
+    const giftWrap = await fetchGiftWrap(orderId);
+    res.json({ ...delivery, gift_wrap: giftWrap });
   } catch (err) {
     console.error("Error fetching delivery:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/apps/shop/metal-mart-frontend/src/app/checkout/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/checkout/page.tsx
@@ -163,7 +163,6 @@ export default function CheckoutPage() {
               />
               <div>
                 <p className="font-medium text-slate-900">🎁 Gift wrap this order (+$4.99)</p>
-                <p className="text-sm text-slate-500">A demo-only wrap option added at checkout.</p>
               </div>
             </label>
             <div className="space-y-2 text-sm text-slate-600">

--- a/apps/shop/metal-mart-frontend/src/app/checkout/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/checkout/page.tsx
@@ -22,6 +22,7 @@ export default function CheckoutPage() {
   const [orderId, setOrderId] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [email, setEmail] = useState("");
+  const [giftWrap, setGiftWrap] = useState(false);
 
   useEffect(() => {
     const raw = localStorage.getItem("metal-mart-cart");
@@ -36,6 +37,8 @@ export default function CheckoutPage() {
   }, []);
 
   const totalCents = cart.reduce((s, i) => s + (i.product?.price_cents ?? 0) * i.quantity, 0);
+  const giftWrapFeeCents = giftWrap ? 499 : 0;
+  const checkoutTotalCents = totalCents + giftWrapFeeCents;
   const orderItems = cart.map(({ productId, quantity }) => ({ productId, quantity }));
 
   const handleSubmit = async () => {
@@ -45,7 +48,12 @@ export default function CheckoutPage() {
       const r = await fetch(`${basePath}/api/orders`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ items: orderItems, total_cents: totalCents, ...(email ? { customer_email: email } : {}) }),
+        body: JSON.stringify({
+          items: orderItems,
+          total_cents: totalCents,
+          gift_wrap: giftWrap,
+          ...(email ? { customer_email: email } : {}),
+        }),
       });
       const data = await r.json();
       if (r.ok) {
@@ -140,9 +148,39 @@ export default function CheckoutPage() {
               </li>
             ))}
           </ul>
-          <p className="mb-6 text-xl font-semibold text-slate-900">
-            Total: ${(totalCents / 100).toFixed(2)}
-          </p>
+          <div className="mb-6 space-y-4 rounded-xl border border-slate-300 bg-white p-5">
+            <label
+              htmlFor="gift-wrap"
+              className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-slate-50 p-4"
+            >
+              <input
+                id="gift-wrap"
+                type="checkbox"
+                checked={giftWrap}
+                onChange={(e) => setGiftWrap(e.target.checked)}
+                data-testid="gift-wrap-checkbox"
+                className="mt-1 h-4 w-4 rounded border-slate-300 text-[#6a4ff5] focus:ring-[#6a4ff5]"
+              />
+              <div>
+                <p className="font-medium text-slate-900">🎁 Gift wrap this order (+$4.99)</p>
+                <p className="text-sm text-slate-500">A demo-only wrap option added at checkout.</p>
+              </div>
+            </label>
+            <div className="space-y-2 text-sm text-slate-600">
+              <div className="flex items-center justify-between">
+                <span>Subtotal</span>
+                <span>${(totalCents / 100).toFixed(2)}</span>
+              </div>
+              <div className="flex items-center justify-between" data-testid="gift-wrap-fee">
+                <span>Gift wrap</span>
+                <span>{giftWrap ? "$4.99" : "$0.00"}</span>
+              </div>
+              <div className="flex items-center justify-between border-t border-slate-200 pt-2 text-xl font-semibold text-slate-900">
+                <span>Total</span>
+                <span data-testid="checkout-total">${(checkoutTotalCents / 100).toFixed(2)}</span>
+              </div>
+            </div>
+          </div>
           <div className="mb-6">
             <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-slate-700">
               Email <span className="text-slate-400">(optional)</span>
@@ -167,6 +205,7 @@ export default function CheckoutPage() {
           <button
             onClick={handleSubmit}
             disabled={submitting}
+            data-testid="place-order-button"
             className="btn-primary w-full rounded-xl px-8 py-3.5 font-semibold disabled:opacity-50 disabled:transform-none disabled:shadow-none sm:w-fit focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
           >
             {submitting ? "Placing order..." : "Place order"}

--- a/apps/shop/metal-mart-frontend/src/app/orders/[id]/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/orders/[id]/page.tsx
@@ -15,6 +15,8 @@ type Order = {
   total_cents: number;
   status: string;
   created_at: string;
+  gift_wrap: boolean;
+  gift_wrap_fee_cents: number;
 };
 type Product = { id: number; name: string; price_cents: number };
 
@@ -22,10 +24,12 @@ export default function OrderPage() {
   const params = useParams();
   const id = params?.id as string;
   const [order, setOrder] = useState<Order | null>(null);
-  const [delivery, setDelivery] = useState<{ status: string } | null>(null);
+  const [delivery, setDelivery] = useState<{ status: string; gift_wrap?: boolean | null } | null>(null);
   const [lineItems, setLineItems] = useState<{ product: Product; quantity: number }[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const itemsSubtotalCents = lineItems.reduce((sum, item) => sum + item.product.price_cents * item.quantity, 0);
+  const isGiftWrapped = (order?.gift_wrap ?? delivery?.gift_wrap) === true;
 
   useEffect(() => {
     if (!id) return;
@@ -99,6 +103,14 @@ export default function OrderPage() {
                 <p className="text-slate-600">
                   Placed: {new Date(order.created_at).toLocaleString()}
                 </p>
+                {isGiftWrapped && (
+                  <p
+                    className="inline-flex rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-800"
+                    data-testid="gift-wrap-indicator"
+                  >
+                    🎁 Gift wrapped
+                  </p>
+                )}
                 {delivery && (
                   <p className="text-slate-600">Delivery: {delivery.status}</p>
                 )}
@@ -119,9 +131,24 @@ export default function OrderPage() {
                       </li>
                     ))}
                   </ul>
-                  <p className="mt-3 text-lg font-semibold text-slate-900">
-                    Total: ${(order.total_cents / 100).toFixed(2)}
-                  </p>
+                  <div className="mt-3 space-y-2">
+                    {order.gift_wrap_fee_cents > 0 && (
+                      <>
+                        <p className="flex justify-between text-slate-600">
+                          <span>Items subtotal</span>
+                          <span>${(itemsSubtotalCents / 100).toFixed(2)}</span>
+                        </p>
+                        <p className="flex justify-between text-slate-600">
+                          <span>Gift wrap fee</span>
+                          <span>${(order.gift_wrap_fee_cents / 100).toFixed(2)}</span>
+                        </p>
+                      </>
+                    )}
+                    <p className="flex justify-between text-lg font-semibold text-slate-900">
+                      <span>Total</span>
+                      <span>${(order.total_cents / 100).toFixed(2)}</span>
+                    </p>
+                  </div>
                 </div>
               )}
             </div>

--- a/apps/shop/order-service/src/activities.ts
+++ b/apps/shop/order-service/src/activities.ts
@@ -8,12 +8,23 @@ export type CheckoutInput = {
   total_cents: number;
   customer_email?: string;
   baggage?: string;
+  gift_wrap?: boolean;
 };
 
 export type CheckoutResult = {
   orderId: number;
   status: string;
 };
+
+const GIFT_WRAP_FEE_CENTS = 499;
+
+function getGiftWrapFeeCents(giftWrap?: boolean): number {
+  return giftWrap ? GIFT_WRAP_FEE_CENTS : 0;
+}
+
+function getOrderTotalCents(input: CheckoutInput): number {
+  return input.total_cents + getGiftWrapFeeCents(input.gift_wrap);
+}
 
 /** Check stock for all items via inventory-service */
 export async function reserveStock(input: CheckoutInput): Promise<void> {
@@ -61,7 +72,12 @@ export async function chargePayment(input: CheckoutInput & { orderId?: number })
   await sqsClient.send(
     new SendMessageCommand({
       QueueUrl: sqsQueueUrl,
-      MessageBody: JSON.stringify({ orderId: input.orderId, amount: input.total_cents, items: input.items, customer_email: input.customer_email ?? null }),
+      MessageBody: JSON.stringify({
+        orderId: input.orderId,
+        amount: getOrderTotalCents(input),
+        items: input.items,
+        customer_email: input.customer_email ?? null,
+      }),
       MessageAttributes: {
         "baggage": {
           DataType: "String",
@@ -74,13 +90,15 @@ export async function chargePayment(input: CheckoutInput & { orderId?: number })
 
 /** Insert order into DB and return orderId */
 export async function createOrder(input: CheckoutInput): Promise<number> {
+  const totalCents = getOrderTotalCents(input);
+  const giftWrapFeeCents = getGiftWrapFeeCents(input.gift_wrap);
   const client = await pool.connect();
   try {
     const {
       rows: [row],
     } = await client.query(
-      "INSERT INTO orders (items, total_cents, status, customer_email) VALUES ($1, $2, 'confirmed', $3) RETURNING id",
-      [JSON.stringify(input.items), input.total_cents, input.customer_email ?? null]
+      "INSERT INTO orders (items, total_cents, status, customer_email, gift_wrap, gift_wrap_fee_cents) VALUES ($1, $2, 'confirmed', $3, $4, $5) RETURNING id",
+      [JSON.stringify(input.items), totalCents, input.customer_email ?? null, input.gift_wrap === true, giftWrapFeeCents]
     );
     return row.id as number;
   } finally {
@@ -94,12 +112,14 @@ export async function publishOrderToKafka(input: {
   items: Array<{ productId: number; quantity: number }>;
   status: string;
   baggage?: string;
+  gift_wrap?: boolean;
 }): Promise<void> {
   await sendOrderToKafka({
     orderId: input.orderId,
     items: input.items,
     status: input.status,
     baggage: input.baggage,
+    gift_wrap: input.gift_wrap,
   });
 }
 
@@ -109,12 +129,13 @@ export async function publishOrderNotificationActivity(input: {
   total_cents: number;
   customer_email?: string;
   baggage?: string;
+  gift_wrap?: boolean;
 }): Promise<void> {
   await publishOrderNotification({
     orderId: input.orderId,
     status: "confirmed",
     customer_email: input.customer_email ?? null,
-    total_cents: input.total_cents,
+    total_cents: input.total_cents + getGiftWrapFeeCents(input.gift_wrap),
     event: "order_confirmed",
     baggage: input.baggage,
   });

--- a/apps/shop/order-service/src/index.ts
+++ b/apps/shop/order-service/src/index.ts
@@ -20,6 +20,7 @@ const JWT_SECRET = process.env.JWT_SECRET || "demo-secret-key";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const workflowBundlePath = path.join(__dirname, "workflow-bundle.js");
+const GIFT_WRAP_FEE_CENTS = 499;
 
 const app = express();
 const port = parseInt(process.env.PORT || "80", 10);
@@ -37,11 +38,19 @@ async function initDb() {
         total_cents INTEGER NOT NULL,
         status VARCHAR(50) DEFAULT 'pending',
         customer_email VARCHAR(255),
+        gift_wrap BOOLEAN NOT NULL DEFAULT FALSE,
+        gift_wrap_fee_cents INTEGER NOT NULL DEFAULT 0,
         created_at TIMESTAMPTZ DEFAULT NOW()
       )
     `);
     await client.query(`
       ALTER TABLE orders ADD COLUMN IF NOT EXISTS customer_email VARCHAR(255)
+    `);
+    await client.query(`
+      ALTER TABLE orders ADD COLUMN IF NOT EXISTS gift_wrap BOOLEAN NOT NULL DEFAULT FALSE
+    `);
+    await client.query(`
+      ALTER TABLE orders ADD COLUMN IF NOT EXISTS gift_wrap_fee_cents INTEGER NOT NULL DEFAULT 0
     `);
   } finally {
     client.release();
@@ -84,6 +93,7 @@ type OrderInput = {
   total_cents: number;
   customer_email?: string;
   baggage?: string;
+  gift_wrap?: boolean;
 };
 
 const MAX_PRODUCT_ID = 2 ** 31 - 1; // safe integer, prevents URL injection
@@ -161,7 +171,9 @@ async function createOrderViaTemporal(
 async function createOrderDirect(
   input: OrderInput
 ): Promise<{ orderId: number; status: string }> {
-  const { items, total_cents: totalCents, customer_email, baggage } = input;
+  const { items, total_cents: baseTotalCents, customer_email, baggage, gift_wrap: giftWrap = false } = input;
+  const giftWrapFeeCents = giftWrap ? GIFT_WRAP_FEE_CENTS : 0;
+  const totalCents = baseTotalCents + giftWrapFeeCents;
 
   for (const item of items) {
     const productId = encodeURIComponent(String(item.productId));
@@ -211,8 +223,8 @@ async function createOrderDirect(
     const {
       rows: [row],
     } = await client.query(
-      "INSERT INTO orders (items, total_cents, status, customer_email) VALUES ($1, $2, 'confirmed', $3) RETURNING id",
-      [JSON.stringify(items), totalCents, customer_email ?? null]
+      "INSERT INTO orders (items, total_cents, status, customer_email, gift_wrap, gift_wrap_fee_cents) VALUES ($1, $2, 'confirmed', $3, $4, $5) RETURNING id",
+      [JSON.stringify(items), totalCents, customer_email ?? null, giftWrap, giftWrapFeeCents]
     );
     orderId = row.id;
   } finally {
@@ -244,6 +256,7 @@ async function createOrderDirect(
     items,
     status: "confirmed",
     baggage,
+    gift_wrap: giftWrap,
   });
 
   await publishOrderNotification({
@@ -260,10 +273,14 @@ async function createOrderDirect(
 
 app.post("/orders", async (req, res) => {
   const baggage = req.headers["baggage"] as string | undefined;
-  const body = req.body as { items?: unknown; total_cents?: number; customer_email?: string };
+  const body = req.body as { items?: unknown; total_cents?: number; customer_email?: string; gift_wrap?: unknown };
   const total_cents = typeof body.total_cents === "number" ? body.total_cents : 0;
   const customer_email = typeof body.customer_email === "string" ? body.customer_email : undefined;
-  console.log("Order request:", JSON.stringify({ baggage, total_cents, customer_email, items: body.items }, null, 2));
+  if (body.gift_wrap !== undefined && typeof body.gift_wrap !== "boolean") {
+    return res.status(400).json({ error: "gift_wrap must be a boolean" });
+  }
+  const gift_wrap = body.gift_wrap === true;
+  console.log("Order request:", JSON.stringify({ baggage, total_cents, customer_email, gift_wrap, items: body.items }, null, 2));
 
   const validated = validateOrderItems(body.items);
   if ("error" in validated) {
@@ -275,7 +292,7 @@ app.post("/orders", async (req, res) => {
   }
   const { items } = validated;
 
-  const input: OrderInput = { items, total_cents, customer_email, baggage };
+  const input: OrderInput = { items, total_cents, customer_email, baggage, gift_wrap };
 
   try {
     const result =
@@ -306,7 +323,7 @@ app.get("/orders/:id", orderReadLimiter, async (req, res) => {
   if (isNaN(id)) return res.status(400).json({ error: "Invalid order ID" });
   try {
     const { rows } = await pool.query(
-      "SELECT id, items, total_cents, status, created_at FROM orders WHERE id = $1",
+      "SELECT id, items, total_cents, status, created_at, gift_wrap, gift_wrap_fee_cents FROM orders WHERE id = $1",
       [id]
     );
     if (rows.length === 0)

--- a/apps/shop/order-service/src/kafka.ts
+++ b/apps/shop/order-service/src/kafka.ts
@@ -5,6 +5,7 @@ export type SendOrderPayload = {
   items: Array<{ productId: number; quantity: number }>;
   status: string;
   baggage?: string;
+  gift_wrap?: boolean;
 };
 
 /**
@@ -12,11 +13,12 @@ export type SendOrderPayload = {
  * Used by both the current implementation and the Temporal publishOrderToKafka activity.
  */
 export async function sendOrderToKafka(payload: SendOrderPayload): Promise<void> {
-  const { orderId, items, status, baggage } = payload;
+  const { orderId, items, status, baggage, gift_wrap = false } = payload;
   const message = {
     orderId,
     items,
     status,
+    gift_wrap,
     timestamp: new Date().toISOString(),
   };
   const kafkaHeaders: Record<string, string> = {};

--- a/apps/shop/order-service/src/workflows/checkout.ts
+++ b/apps/shop/order-service/src/workflows/checkout.ts
@@ -16,6 +16,7 @@ export type CheckoutInput = {
   total_cents: number;
   customer_email?: string;
   baggage?: string;
+  gift_wrap?: boolean;
 };
 
 export type CheckoutResult = {
@@ -35,12 +36,14 @@ export async function CheckoutWorkflow(
     items: input.items,
     status: "confirmed",
     baggage: input.baggage,
+    gift_wrap: input.gift_wrap,
   });
   await publishOrderNotificationActivity({
     orderId,
     total_cents: input.total_cents,
     customer_email: input.customer_email,
     baggage: input.baggage,
+    gift_wrap: input.gift_wrap,
   });
   return { orderId, status: "confirmed" };
 }


### PR DESCRIPTION
## Summary
- add a checkout gift-wrap option with stable preview selectors
- persist gift wrap fields and fee in order-service while applying the fee server-side
- expose gift wrap on delivery status and show the wrapped state on the order details page

## Verification
- npm run lint (order-service)
- npm run lint (delivery-service)
- npm run build (metal-mart-frontend)
- npm run build (order-service)
- npm run build (delivery-service)