### PR TITLE
Change featured products heading to test title

### DIFF
--- a/apps/shop/metal-mart-frontend/src/app/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/page.tsx
@@ -185,7 +185,7 @@ export default function Home() {
           <div className="mx-auto max-w-6xl">
             {hasProducts && (
               <h1 className="hand-drawn-underline mb-10 inline-block text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl md:text-5xl">
-                Featured products
+                test title
               </h1>
             )}
             {hasProducts ? (


### PR DESCRIPTION
## Summary
- Changed the "Featured products" heading on the MetalMart home page to "test title"

## Test plan
- [ ] Visit the home page and confirm the heading reads "test title"

🤖 Generated with [Claude Code](https://claude.com/claude-code)