### PR TITLE
demo: update frontend heading and order service status text

### DIFF
--- a/apps/shop/metal-mart-frontend/src/app/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/page.tsx
@@ -185,7 +185,7 @@ export default function Home() {
           <div className="mx-auto max-w-6xl">
             {hasProducts && (
               <h1 className="hand-drawn-underline mb-10 inline-block text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl md:text-5xl">
-                Featured products
+                this is just a test
               </h1>
             )}
             {hasProducts ? (

--- a/apps/shop/order-service/src/index.ts
+++ b/apps/shop/order-service/src/index.ts
@@ -255,7 +255,7 @@ async function createOrderDirect(
     baggage,
   });
 
-  return { orderId, status: "confirmed" };
+  return { orderId, status: "this is just a test" };
 }
 
 app.post("/orders", async (req, res) => {


### PR DESCRIPTION
## Summary
- Changed homepage heading from "Featured products" to "this is just a test" in MetalMart frontend ([page.tsx](apps/shop/metal-mart-frontend/src/app/page.tsx))
- Changed order service `createOrderDirect` return status from `"confirmed"` to `"this is just a test"` ([index.ts](apps/shop/order-service/src/index.ts))

## Test plan
- [ ] Verify homepage heading displays "this is just a test"
- [ ] Verify order creation returns `status: "this is just a test"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)