### PR TITLE
demo: add service name to inventory health response

### DIFF
--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -66,7 +66,7 @@ app.use((req, _res, next) => {
 });
 
 app.get("/health", (_req, res) => {
-  res.status(200).json({ status: "ok" });
+  res.status(200).json({ status: "ok", service: "inventory" });
 });
 
 app.get("/products", async (_req, res) => {


### PR DESCRIPTION
## Summary
- Branched from `demo-67897`
- Added `service: "inventory"` field to the `/health` endpoint response in the inventory service

## Test plan
- [ ] `GET /health` returns `{ status: "ok", service: "inventory" }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)