### PR TITLE
demo: frontend heading + order status update for 345467

### DIFF
--- a/apps/shop/metal-mart-frontend/src/app/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/page.tsx
@@ -185,7 +185,7 @@ export default function Home() {
           <div className="mx-auto max-w-6xl">
             {hasProducts && (
               <h1 className="hand-drawn-underline mb-10 inline-block text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl md:text-5xl">
-                Featured products
+                New arrivals just dropped
               </h1>
             )}
             {hasProducts ? (

--- a/apps/shop/order-service/src/index.ts
+++ b/apps/shop/order-service/src/index.ts
@@ -255,7 +255,7 @@ async function createOrderDirect(
     baggage,
   });
 
-  return { orderId, status: "confirmed" };
+  return { orderId, status: "processing" };
 }
 
 app.post("/orders", async (req, res) => {


### PR DESCRIPTION
## Summary
- Updated MetalMart frontend heading from "Featured products" to "New arrivals just dropped"
- Changed order service return status from `"confirmed"` to `"processing"`

## Test plan
- [ ] Verify home page heading shows "New arrivals just dropped"
- [ ] Verify order creation returns `status: "processing"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)