### PR TITLE
match /preview as substring instead of exact body

### DIFF
--- a/.github/workflows/preview-shop-pr-command.yml
+++ b/.github/workflows/preview-shop-pr-command.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   dispatch-gate:
     name: Dispatch E2E gate from /preview comment
-    if: github.event.issue.pull_request && github.event.comment.body == '/preview'
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/preview')
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
Allow PR comments like "please /preview this" or "/preview\n\ncc @reviewer" to trigger the gate. Previously the body had to equal '/preview' exactly, which surprised users who added context to their comment.