### PR TITLE
fix(pubsub-consumer): tighten mirrord config for GCP Pub/Sub splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ base/charts
 # Local-only minikube shop script (contains mirrord license key; do not commit)
 apps/shop/scripts/setup-minikube-shop.sh
 
+# Python virtual environments
+.venv/
+venv/
+
 # Node dependencies
 **/node_modules
 

--- a/apps/shop/order-events-pubsub-consumer/mirrord.json
+++ b/apps/shop/order-events-pubsub-consumer/mirrord.json
@@ -6,6 +6,13 @@
     }
   },
   "feature": {
+    "fs": "local",
+    "env": {
+      "include": "GOOGLE_CLOUD_PROJECT;PUBSUB_SUBSCRIPTION_ID;LOG_LEVEL",
+      "override": {
+        "PORT": "8080"
+      }
+    },
     "split_queues": {
       "order-pubsub": {
         "queue_type": "GCPPubSub",

--- a/manifests/shop/base/app/order-events-pubsub-consumer/deployment.yaml
+++ b/manifests/shop/base/app/order-events-pubsub-consumer/deployment.yaml
@@ -16,8 +16,7 @@ spec:
       labels:
         app: order-events-pubsub-consumer
     spec:
-      # Bind a GCP service account with roles/pubsub.subscriber via Workload Identity:
-      # serviceAccountName: order-events-pubsub
+      serviceAccountName: order-events-pubsub
       containers:
         - name: main
           image: ghcr.io/metalbear-co/playground-order-events-pubsub-consumer:latest

--- a/manifests/shop/base/app/order-events-pubsub-consumer/kustomization.yaml
+++ b/manifests/shop/base/app/order-events-pubsub-consumer/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - service-account.yaml
   - deployment.yaml
   - svc.yaml
   - mirrord-split-config.yaml

--- a/manifests/shop/base/app/order-events-pubsub-consumer/service-account.yaml
+++ b/manifests/shop/base/app/order-events-pubsub-consumer/service-account.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: order-events-pubsub
+  annotations:
+    iam.gke.io/gcp-service-account: order-events-pubsub@playground-383912.iam.gserviceaccount.com


### PR DESCRIPTION
## Summary
- Tune `mirrord.json` for the order-events Pub/Sub consumer demo: **local filesystem**, **narrow remote env imports** (`GOOGLE_CLOUD_PROJECT`, `PUBSUB_SUBSCRIPTION_ID`, `LOG_LEVEL`), and **`PORT` override** to `8080` so Flask works when targeting the deployment that listens on container port 80.

## Deploy / IAM note
Applying split subscriptions succeeds when identities used via mirrored metadata have **Pub/Sub consume** permission. See infra PR granting `roles/pubsub.subscriber` to the default Compute Engine SA (linked once opened).

## Test plan
- [ ] `mirrord exec -f apps/shop/order-events-pubsub-consumer/mirrord.json -- .venv/bin/python3 -u main.py` reaches `Subscribing to ...mirrord-tmp-...` without Flask port conflict.
- [ ] Publish a test message with `tenant` matching `demo-local.*`; confirm receipt in logs.


Made with [Cursor](https://cursor.com)