### PR TITLE
shop: Workload Identity for order-service Pub/Sub

### DIFF
--- a/manifests/shop/base/app/order-service/deployment.yaml
+++ b/manifests/shop/base/app/order-service/deployment.yaml
@@ -11,6 +11,7 @@ spec:
       labels:
         app: order-service
     spec:
+      serviceAccountName: order-service-pubsub
       containers:
         - name: main
           image: ghcr.io/metalbear-co/playground-order-service:latest

--- a/manifests/shop/base/app/order-service/kustomization.yaml
+++ b/manifests/shop/base/app/order-service/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - banner-configmap.yaml
+  - service-account.yaml
   - deployment.yaml
   - svc.yaml

--- a/manifests/shop/base/app/order-service/service-account.yaml
+++ b/manifests/shop/base/app/order-service/service-account.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: order-service-pubsub
+  annotations:
+    iam.gke.io/gcp-service-account: order-service-pubsub@playground-383912.iam.gserviceaccount.com


### PR DESCRIPTION
## Summary
- Add `ServiceAccount` `order-service-pubsub` annotated for `order-service-pubsub@playground-383912.iam.gserviceaccount.com`.
- Set `serviceAccountName` on the `order-service` Deployment so publishes use the GCP SA from [infra](https://github.com/metalbear-co/infra) (requires merged Terraform + apply).

## Test plan
- [ ] Merge infra PR and apply Terraform first.
- [ ] Roll out / sync manifests and checkout in playground; confirm no `[Order/PubSub] publish failed` / `PERMISSION_DENIED` in order-service logs.

Made with [Cursor](https://cursor.com)