### PR TITLE
demo: return "confirmed super" status from order-service

### DIFF
--- a/apps/shop/order-service/mirrord-order-db.json
+++ b/apps/shop/order-service/mirrord-order-db.json
@@ -18,7 +18,7 @@
       "outgoing":true
     },"db_branches": [
     {
-      "id": "ari09-branch-db",
+      "id": "{{key}}",
       "type": "pg",
       "ttl_secs": 30,    
       "version": "16.0",

--- a/apps/shop/order-service/src/index.ts
+++ b/apps/shop/order-service/src/index.ts
@@ -265,7 +265,7 @@ async function createOrderDirect(
     baggage,
   });
 
-  return { orderId, status: "confirmed" };
+  return { orderId, status: "confirmed super" };
 }
 
 app.post("/orders", async (req, res) => {


### PR DESCRIPTION
## Summary
- Change `createOrderDirect` response in `order-service` to return `status: "confirmed super"` instead of `status: "confirmed"`
- Parameterize `id` in `mirrord-order-db.json` to use `{{key}}` template

## Test plan
- [ ] `POST /orders` returns `status: "confirmed super"` in direct (non-temporal) mode
- [ ] mirrord db-branching config still resolves with templated `id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)