### PR TITLE
shop: VS Code launch + local port for Pub/Sub consumer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -180,6 +180,39 @@
             "env": {
                 "NEXT_PUBLIC_VISUALIZATION_BACKEND_URL": "http://localhost:8080"
             }
+        },
+        {
+            "name": "shop-pubsub-consumer (mirrord)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/apps/shop/order-events-pubsub-consumer/main.py",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/apps/shop/order-events-pubsub-consumer",
+            "python": "${workspaceFolder}/apps/shop/order-events-pubsub-consumer/.venv/bin/python",
+            "env": {
+                "PYTHONNOUSERSITE": "1",
+                "GOOGLE_CLOUD_PROJECT": "playground-383912",
+                "PUBSUB_SUBSCRIPTION_ID": "metal-mart-order-events-sub",
+                "PORT": "8081",
+                "MIRRORD_ACTIVE": "1",
+                "MIRRORD_CONFIG_FILE": "${workspaceFolder}/apps/shop/order-events-pubsub-consumer/mirrord.json"
+            }
+        },
+        {
+            "name": "shop-pubsub-consumer (local, no mirrord)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/apps/shop/order-events-pubsub-consumer/main.py",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/apps/shop/order-events-pubsub-consumer",
+            "python": "${workspaceFolder}/apps/shop/order-events-pubsub-consumer/.venv/bin/python",
+            "env": {
+                "PYTHONNOUSERSITE": "1",
+                "GOOGLE_CLOUD_PROJECT": "playground-383912",
+                "PUBSUB_SUBSCRIPTION_ID": "metal-mart-order-events-sub",
+                "PORT": "8081",
+                "MIRRORD_ACTIVE": "0"
+            }
         }
     ]
 }

--- a/apps/shop/order-events-pubsub-consumer/mirrord.json
+++ b/apps/shop/order-events-pubsub-consumer/mirrord.json
@@ -10,7 +10,7 @@
     "env": {
       "include": "GOOGLE_CLOUD_PROJECT;PUBSUB_SUBSCRIPTION_ID;LOG_LEVEL",
       "override": {
-        "PORT": "8080"
+        "PORT": "8081"
       }
     },
     "split_queues": {


### PR DESCRIPTION
## Summary

- Add VS Code / Cursor **Run and Debug** configs for `order-events-pubsub-consumer`: one with mirrord (`MIRRORD_ACTIVE=1` + `mirrord.json`), one local-only.
- Use the project `.venv` Python and `PYTHONNOUSERSITE=1` to avoid broken system `~/Library/Python/3.9` packages on macOS.
- Set local `PORT` to **8081** in `mirrord.json` (was 8080) so Flask health checks do not collide with HTTPS probes to localhost:8080 from mirrord UI / browser tooling.

## Test plan

- [ ] Run **shop-pubsub-consumer (mirrord)** from Run and Debug; confirm `Subscribing to .../mirrord-tmp-...` and no TLS `400` spam on the health port.
- [ ] Place a checkout on playground shop or `gcloud pubsub topics publish` with `tenant=demo-local-test`; confirm `Pub/Sub message` in the debug terminal.
- [ ] Run **shop-pubsub-consumer (local, no mirrord)** with ADC (`gcloud auth application-default login`) on port 8081.


Made with [Cursor](https://cursor.com)