### PR TITLE
Rename inventory mirrord rule to 00- prefix and always apply

### DIFF
--- a/.cursor/rules/00-mirrord-inventory-service.mdc
+++ b/.cursor/rules/00-mirrord-inventory-service.mdc
@@ -3,7 +3,7 @@ description: Use mirrord filtered traffic when implementing or testing MetalMart
 globs:
   - apps/shop/inventory-service/**
   - apps/shop/metal-mart-frontend/src/app/api/products*/**
-alwaysApply: false
+alwaysApply: true
 ---
 
 # Inventory Service Mirrord Workflow


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renames `.cursor/rules/mirrord-inventory-service.mdc` to `.cursor/rules/00-mirrord-inventory-service.mdc` and sets `alwaysApply: true` so the mirrord workflow is injected into every agent session.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d98e5796-ddfe-49a7-a9d4-e06db2a2565d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d98e5796-ddfe-49a7-a9d4-e06db2a2565d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

