### PR TITLE
Return lowercase product names at inventory API representation layer

### DIFF
--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import rateLimit from "express-rate-limit";
 import { Pool } from "pg";
+import { toProductRepresentation } from "./representation.js";
 
 const app = express();
 const port = parseInt(process.env.PORT || "80", 10);
@@ -73,7 +74,7 @@ app.get("/products", async (_req, res) => {
   // Set a breakpoint here; trigger with: curl http://localhost:28080/products -H "X-PG-Tenant: dev" (while port-forward + mirrord are running)
   try {
     const { rows } = await pool.query("SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id");
-    res.json(rows);
+    res.json(rows.map(toProductRepresentation));
   } catch (err) {
     console.error("Error fetching products:", err);
     res.status(500).json({ error: "Internal server error" });
@@ -93,7 +94,7 @@ app.get("/products/:id", async (req, res) => {
     if (rows.length === 0) {
       return res.status(404).json({ error: "Product not found" });
     }
-    res.json(rows[0]);
+    res.json(toProductRepresentation(rows[0]));
   } catch (err) {
     console.error("Error fetching product:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/apps/shop/inventory-service/src/representation.ts
+++ b/apps/shop/inventory-service/src/representation.ts
@@ -1,0 +1,18 @@
+export type ProductRow = {
+  id: number;
+  name: string;
+  description: string | null;
+  price_cents: number;
+  stock: number;
+  image_url?: string | null;
+  image_urls?: unknown;
+  is_new?: boolean;
+};
+
+/** API representation: stored name unchanged; response uses lowercase. */
+export function toProductRepresentation(row: ProductRow) {
+  return {
+    ...row,
+    name: row.name.toLowerCase(),
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Product names are now lowercased when inventory-service serializes `GET /products` and `GET /products/:id` responses. Database values are unchanged; only the API representation is transformed via `toProductRepresentation`.

## Changes

- Added `apps/shop/inventory-service/src/representation.ts` with `toProductRepresentation`
- Applied the mapper in both product read endpoints in `index.ts`

## Verification

- `npm --prefix apps/shop/inventory-service run lint`
- `npm --prefix apps/shop/inventory-service run build`
- mirrord (`mirrord-session=cursor-lowercase-916b`):
  - **Filtered** `GET /shop/api/products/1` → `"name":"team work makes the dream work sticker"`
  - **Unfiltered** first product name → `Team Work Makes The Dream Work Sticker` (cluster default, unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ef72fc8-6f9c-45a0-85a2-7641686e916b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ef72fc8-6f9c-45a0-85a2-7641686e916b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

