### PR TITLE
fix(inventory): normalize malformed image_urls in API responses

### DIFF
--- a/apps/shop/inventory-service/package.json
+++ b/apps/shop/inventory-service/package.json
@@ -7,7 +7,8 @@
     "inventory-service-dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "node --import tsx --test src/productImages.test.ts"
   },
   "dependencies": {
     "express": "^5.1.0",

--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import rateLimit from "express-rate-limit";
 import { Pool } from "pg";
+import { normalizeProductImages } from "./productImages.js";
 
 const app = express();
 const port = parseInt(process.env.PORT || "80", 10);
@@ -73,7 +74,7 @@ app.get("/products", async (_req, res) => {
   // Set a breakpoint here; trigger with: curl http://localhost:28080/products -H "X-PG-Tenant: dev" (while port-forward + mirrord are running)
   try {
     const { rows } = await pool.query("SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id");
-    res.json(rows);
+    res.json(rows.map((row) => normalizeProductImages(row)));
   } catch (err) {
     console.error("Error fetching products:", err);
     res.status(500).json({ error: "Internal server error" });
@@ -93,7 +94,7 @@ app.get("/products/:id", async (req, res) => {
     if (rows.length === 0) {
       return res.status(404).json({ error: "Product not found" });
     }
-    res.json(rows[0]);
+    res.json(normalizeProductImages(rows[0]));
   } catch (err) {
     console.error("Error fetching product:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/apps/shop/inventory-service/src/productImages.test.ts
+++ b/apps/shop/inventory-service/src/productImages.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeProductImages, parseImageUrls } from "./productImages.js";
+
+test("parseImageUrls drops empty strings", () => {
+  assert.deepEqual(parseImageUrls(["", "Metal Mart/samples/mirrord-hoodie-front"]), [
+    "Metal Mart/samples/mirrord-hoodie-front",
+  ]);
+});
+
+test("parseImageUrls parses JSON string arrays", () => {
+  assert.deepEqual(parseImageUrls('["a.jpg", "b.jpg"]'), ["a.jpg", "b.jpg"]);
+});
+
+test("normalizeProductImages falls back to image_url", () => {
+  const normalized = normalizeProductImages({
+    image_url: "legacy.png",
+    image_urls: ["", "  "],
+  });
+  assert.deepEqual(normalized.image_urls, ["legacy.png"]);
+  assert.equal(normalized.image_url, "legacy.png");
+});
+
+test("normalizeProductImages keeps valid image_urls", () => {
+  const normalized = normalizeProductImages({
+    image_url: null,
+    image_urls: ["front_id", "back_id"],
+  });
+  assert.deepEqual(normalized.image_urls, ["front_id", "back_id"]);
+});

--- a/apps/shop/inventory-service/src/productImages.ts
+++ b/apps/shop/inventory-service/src/productImages.ts
@@ -1,0 +1,65 @@
+/** Product row fields used when normalizing catalogue images for API responses. */
+export type ProductImageFields = {
+  image_url?: string | null;
+  image_urls?: unknown;
+};
+
+function trimUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** Coerce DB JSONB / legacy values into a list of non-empty image URL strings. */
+export function parseImageUrls(raw: unknown): string[] {
+  if (raw == null) return [];
+
+  let value: unknown = raw;
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return [];
+    try {
+      value = JSON.parse(trimmed) as unknown;
+    } catch {
+      const single = trimUrl(trimmed);
+      return single ? [single] : [];
+    }
+  }
+
+  if (Array.isArray(value)) {
+    const urls: string[] = [];
+    for (const item of value) {
+      const url = trimUrl(item);
+      if (url) urls.push(url);
+    }
+    return urls;
+  }
+
+  if (typeof value === "object") {
+    const urls: string[] = [];
+    for (const item of Object.values(value as Record<string, unknown>)) {
+      const url = trimUrl(item);
+      if (url) urls.push(url);
+    }
+    return urls;
+  }
+
+  return [];
+}
+
+/** Ensure clients always receive a clean image_urls array (and legacy image_url when useful). */
+export function normalizeProductImages<T extends ProductImageFields>(product: T): T & { image_urls: string[] } {
+  const image_url = trimUrl(product.image_url);
+  let image_urls = parseImageUrls(product.image_urls);
+
+  if (image_urls.length === 0 && image_url) {
+    image_urls = [image_url];
+  }
+
+  return {
+    ...product,
+    image_url: image_url ?? product.image_url ?? null,
+    image_urls,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Products in the playground DB can have `image_urls` arrays that include empty strings (e.g. product 2: `["", "Metal Mart/samples/mirrord-hoodie-front"]`). The shop UI uses the first array entry as the primary image, so an empty leading value hides the product image even when `image_url` is set.

This change normalizes catalogue responses in `inventory-service` before returning them:

- Strip empty / whitespace-only entries from `image_urls`
- Parse JSON-string-encoded arrays when present
- Fall back to legacy `image_url` when no valid URLs remain

## Verification

- `npm --prefix apps/shop/inventory-service run lint`
- `npm --prefix apps/shop/inventory-service run test`
- mirrord filtered traffic to `https://playground.metalbear.dev/shop/api/products/2` returns cleaned `image_urls`; unfiltered traffic still hits cluster baseline (malformed until deploy)

## Test plan

- [x] Unit tests for `parseImageUrls` / `normalizeProductImages`
- [x] mirrord: filtered `GET /shop/api/products/2` shows `image_urls: ["Metal Mart/samples/mirrord-hoodie-front"]`
- [ ] Deploy inventory-service image and confirm unfiltered traffic is fixed in production
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7a81cf7-49f3-470b-a9e0-0556ad762ceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7a81cf7-49f3-470b-a9e0-0556ad762ceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

