### PR TITLE
Add Cursor rule: no public endpoint debugging without mirrord

### DIFF
--- a/.cursor/rules/00-developer-workflow-mirrord-only.mdc
+++ b/.cursor/rules/00-developer-workflow-mirrord-only.mdc
@@ -1,0 +1,45 @@
+---
+description: Forbid debugging via public playground endpoints unless traffic is routed through mirrord.
+alwaysApply: true
+---
+
+# Developer workflow: public endpoints only via mirrord
+
+This rule applies to **every** task in this repository.
+
+## Forbidden — public endpoint debugging
+
+Do **not** use deployed or public URLs to debug, inspect, or verify application behavior unless mirrord is actively stealing filtered traffic to your local process.
+
+That includes:
+
+- **Unfiltered HTTP to the playground** — do not `curl`, `wget`, or use an HTTP client against `https://playground.metalbear.dev/...` (or other live shop URLs) to check whether a code change works, to read API responses as ground truth, or to iterate on fixes.
+- **Treating cluster/production responses as the primary test signal** — do not mark work complete because an unfiltered public request returned the expected JSON or status.
+- **In-cluster shortcuts instead of mirrord** — do not use `kubectl port-forward`, in-cluster service URLs (`http://inventory-service/...`), or curl pods inside the cluster as the main way to validate shop backend behavior.
+
+Unfiltered requests to the same public URL are allowed **only** to confirm that traffic **does not** reach your local process while mirrord is running (traffic isolation), not to verify feature behavior.
+
+## Allowed — mirrord-filtered public path
+
+Public shop URLs may be used **only** when all of the following are true:
+
+1. The target service runs **locally** under `mirrord exec` with the repo’s `mirrord.json` (do not widen `http_filter`).
+2. Requests include the session baggage header, e.g. `baggage: mirrord-session=<MIRRORD_SESSION>`, matching the active mirrord session.
+3. You confirm filtered traffic hits the local process (logs) and changed behavior appears in the **filtered** response.
+
+For inventory-service and product catalogue API work, follow the full workflow in `.cursor/rules/00-mirrord-inventory-service.mdc` and the `mirrord-run-shop` skill.
+
+## Allowed — normal local development
+
+Without mirrord, use the workflow a developer runs on their machine:
+
+- Edit and build source in the repo
+- Run services locally (`npm run dev`, tests, Docker Compose, etc.)
+- Unit, integration, and e2e tests defined in the project
+- Browser or Playwright against a **local** dev server
+
+If a dependency is not available locally, prefer mocks, fixtures, and project test suites — or ask the user to run a check — instead of probing live public endpoints.
+
+## Completion
+
+Do not claim playground or production verification from unfiltered public traffic. For shop inventory changes, completion requires mirrord filtered verification as described in the inventory mirrord rule.

--- a/.cursor/skills/mirrord-run-shop/SKILL.md
+++ b/.cursor/skills/mirrord-run-shop/SKILL.md
@@ -5,5 +5,8 @@ description: REQUIRED before completing any inventory-service (or shop product A
 
 # Mirrord Run Shop
 
-Use the workflow in `.cursor/rules/mirrord-inventory-service.mdc` before completing inventory-service
+Public playground URLs are for mirrord-filtered verification only; see
+`.cursor/rules/00-developer-workflow-mirrord-only.mdc`.
+
+Use the workflow in `.cursor/rules/00-mirrord-inventory-service.mdc` before completing inventory-service
 or shop product API changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ Use this file and `docs/` for project context when working in this repo.
 - When starting a feature, look in `docs/` for an existing plan (end-state, migration) and follow it.
 - Commit planning or context docs in the **same branch/PR** as the implementation so git history carries the plan.
 - Prefer minimal, directive context; avoid long prose.
-- For inventory-service changes, use the mirrord filtered-traffic workflow in `.cursor/rules/mirrord-inventory-service.mdc`.
+- Do not debug via public playground endpoints without mirrord: `.cursor/rules/00-developer-workflow-mirrord-only.mdc`.
+- For inventory-service changes, use the mirrord filtered-traffic workflow in `.cursor/rules/00-mirrord-inventory-service.mdc`.
 
 ## Build and deploy
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an always-applied Cursor rule that blocks agents from using live playground/public URLs for debugging or verification unless traffic is routed through **mirrord** to a local process with the matching `mirrord-session` baggage header.

## Changes

- **`.cursor/rules/00-developer-workflow-mirrord-only.mdc`** — New developer workflow rule:
  - **Forbidden:** unfiltered `curl`/HTTP to `https://playground.metalbear.dev/...`, treating cluster responses as primary test signal, port-forward/in-cluster URLs as main validation path
  - **Allowed:** public shop URLs only under active `mirrord exec` with filtered baggage; unfiltered requests only to prove traffic isolation
  - **Allowed:** normal local dev, tests, Playwright against local servers
- **`AGENTS.md`** — Links to the new rule; fixes inventory mirrord rule path to `00-mirrord-inventory-service.mdc`
- **`.cursor/skills/mirrord-run-shop/SKILL.md`** — Points agents at the new rule before the inventory mirrord workflow

The existing inventory mirrord workflow rule (`00-mirrord-inventory-service.mdc`) is unchanged.

## Motivation

Agents should not treat production/playground HTTP responses as ground truth when iterating on code. For shop backend work, verification must go through mirrord-filtered traffic on the same public path users take—not ad-hoc probing of live endpoints.

## Notes

- Docs/rules only; no application code changes.
- Complements (does not replace) `00-mirrord-inventory-service.mdc`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e81f9ac2-2fd2-4497-80cd-54d132ff0978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e81f9ac2-2fd2-4497-80cd-54d132ff0978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

