### PR TITLE
Fix malformed image_urls so shop product images load

### DIFF
--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import rateLimit from "express-rate-limit";
-import { Pool } from "pg";
+import { Pool, type PoolClient } from "pg";
 
 const app = express();
 const port = parseInt(process.env.PORT || "80", 10);
@@ -26,38 +26,34 @@ type ProductRow = {
 
 type ProductResponse = Omit<ProductRow, "image_urls"> & { image_urls: string[] };
 
+/** Canonical Cloudinary public IDs for the core catalog (matches CI seed). */
+const CANONICAL_IMAGE_URLS: Record<number, string[]> = {
+  1: ["team_work_makes_the_Dream_work_ljp4we"],
+  2: ["team_Work_makes_the_Dream_Work_-_front_w5qdnb", "team_work_makes_the_dream_work_-_back_onanux"],
+  3: ["Mind_the_Gap_pkyuc6"],
+  4: ["Mind_the_gap_-_Front_anazkh", "Mind_the_gap_-_Back_oh9jyf"],
+  5: ["Increase_velocity_mfsov2"],
+  6: ["Increase_Velocity_-_Front_c2dgw6", "Increase_Velocity_-_Back_ywhxi6"],
+  7: ["Cloudboat_Willie_-_Front_wpgqi2", "Cloudboat_Willie_-_Back_z05dna"],
+  8: ["A_mirrord_is_born_-_Front_xy8l8p", "A_mirrord_is_born_-_Back_bytwh2"],
+};
+
 function isNonEmptyImageUrl(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-/** Coerce JSONB image_urls into a string[] the shop UI can render; fall back to image_url. */
+/** Drop empty entries; use image_url only when the array has no usable URLs. */
 function normalizeImageUrls(raw: unknown, legacyImageUrl: string | null | undefined): string[] {
   const fallback = isNonEmptyImageUrl(legacyImageUrl) ? legacyImageUrl.trim() : null;
+  const fromArray = Array.isArray(raw)
+    ? raw.filter(isNonEmptyImageUrl).map((url) => url.trim())
+    : isNonEmptyImageUrl(raw)
+      ? [raw.trim()]
+      : [];
 
-  if (raw == null) {
-    return fallback ? [fallback] : [];
+  if (fromArray.length > 0) {
+    return fromArray;
   }
-
-  if (typeof raw === "string") {
-    const trimmed = raw.trim();
-    if (trimmed.startsWith("[")) {
-      try {
-        return normalizeImageUrls(JSON.parse(trimmed), legacyImageUrl);
-      } catch {
-        return fallback ? [fallback] : [];
-      }
-    }
-    return isNonEmptyImageUrl(trimmed) ? [trimmed] : fallback ? [fallback] : [];
-  }
-
-  if (Array.isArray(raw)) {
-    const urls = raw.filter(isNonEmptyImageUrl).map((url) => url.trim());
-    if (urls.length > 0) {
-      return urls;
-    }
-    return fallback ? [fallback] : [];
-  }
-
   return fallback ? [fallback] : [];
 }
 
@@ -65,9 +61,42 @@ function toProductResponse(row: ProductRow): ProductResponse {
   const image_urls = normalizeImageUrls(row.image_urls, row.image_url);
   return {
     ...row,
-    image_url: image_urls[0] ?? row.image_url,
+    image_url: image_urls[0] ?? null,
     image_urls,
   };
+}
+
+/** Repair JSONB arrays that contain empty strings or known-bad demo edits. */
+async function repairMalformedImageUrls(client: PoolClient) {
+  await client.query(`
+    UPDATE products
+    SET image_urls = COALESCE(
+      (
+        SELECT jsonb_agg(to_jsonb(trim(elem)))
+        FROM jsonb_array_elements_text(image_urls) AS elem
+        WHERE trim(elem) <> ''
+      ),
+      '[]'::jsonb
+    )
+    WHERE image_urls IS NOT NULL
+      AND jsonb_typeof(image_urls) = 'array'
+      AND image_urls::text LIKE '%""%'
+  `);
+
+  for (const [idStr, canonical] of Object.entries(CANONICAL_IMAGE_URLS)) {
+    const id = Number(idStr);
+    await client.query(
+      `UPDATE products
+       SET image_urls = $1::jsonb, image_url = NULL
+       WHERE id = $2
+         AND (
+           image_urls::text LIKE '%""%'
+           OR image_url ILIKE '%mirrord-hoodie%'
+           OR image_urls::text ILIKE '%mirrord-hoodie%'
+         )`,
+      [JSON.stringify(canonical), id]
+    );
+  }
 }
 
 async function initDb() {
@@ -108,6 +137,7 @@ async function initDb() {
       UPDATE products SET image_urls = jsonb_build_array(image_url)
       WHERE (image_urls IS NULL OR image_urls = '[]'::jsonb) AND image_url IS NOT NULL
     `);
+    await repairMalformedImageUrls(client);
   } finally {
     client.release();
   }

--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -13,6 +13,63 @@ if (dbUrl && !/:\d+\/.+$/.test(dbUrl)) {
 
 const pool = new Pool({ connectionString: dbUrl });
 
+type ProductRow = {
+  id: number;
+  name: string;
+  description: string | null;
+  price_cents: number;
+  stock: number;
+  image_url: string | null;
+  image_urls: unknown;
+  is_new: boolean;
+};
+
+type ProductResponse = Omit<ProductRow, "image_urls"> & { image_urls: string[] };
+
+function isNonEmptyImageUrl(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** Coerce JSONB image_urls into a string[] the shop UI can render; fall back to image_url. */
+function normalizeImageUrls(raw: unknown, legacyImageUrl: string | null | undefined): string[] {
+  const fallback = isNonEmptyImageUrl(legacyImageUrl) ? legacyImageUrl.trim() : null;
+
+  if (raw == null) {
+    return fallback ? [fallback] : [];
+  }
+
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (trimmed.startsWith("[")) {
+      try {
+        return normalizeImageUrls(JSON.parse(trimmed), legacyImageUrl);
+      } catch {
+        return fallback ? [fallback] : [];
+      }
+    }
+    return isNonEmptyImageUrl(trimmed) ? [trimmed] : fallback ? [fallback] : [];
+  }
+
+  if (Array.isArray(raw)) {
+    const urls = raw.filter(isNonEmptyImageUrl).map((url) => url.trim());
+    if (urls.length > 0) {
+      return urls;
+    }
+    return fallback ? [fallback] : [];
+  }
+
+  return fallback ? [fallback] : [];
+}
+
+function toProductResponse(row: ProductRow): ProductResponse {
+  const image_urls = normalizeImageUrls(row.image_urls, row.image_url);
+  return {
+    ...row,
+    image_url: image_urls[0] ?? row.image_url,
+    image_urls,
+  };
+}
+
 async function initDb() {
   const client = await pool.connect();
   try {
@@ -72,8 +129,10 @@ app.get("/health", (_req, res) => {
 app.get("/products", async (_req, res) => {
   // Set a breakpoint here; trigger with: curl http://localhost:28080/products -H "X-PG-Tenant: dev" (while port-forward + mirrord are running)
   try {
-    const { rows } = await pool.query("SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id");
-    res.json(rows);
+    const { rows } = await pool.query<ProductRow>(
+      "SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id"
+    );
+    res.json(rows.map(toProductResponse));
   } catch (err) {
     console.error("Error fetching products:", err);
     res.status(500).json({ error: "Internal server error" });
@@ -86,14 +145,14 @@ app.get("/products/:id", async (req, res) => {
     return res.status(400).json({ error: "Invalid product ID" });
   }
   try {
-    const { rows } = await pool.query(
+    const { rows } = await pool.query<ProductRow>(
       "SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products WHERE id = $1",
       [id]
     );
     if (rows.length === 0) {
       return res.status(404).json({ error: "Product not found" });
     }
-    res.json(rows[0]);
+    res.json(toProductResponse(rows[0]));
   } catch (err) {
     console.error("Error fetching product:", err);
     res.status(500).json({ error: "Internal server error" });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Product 2 (and potentially others) had corrupted `image_urls` in Postgres, e.g.:

```json
["", "Metal Mart/samples/mirrord-hoodie-front"]
```

Two separate failures:

1. **Frontend picks `image_urls[0]`** — an empty string is truthy for `length > 0` but falsy as an image `src`, so nothing renders.
2. **Invalid Cloudinary ID** — `mirrord-hoodie-front` does not exist (404). The correct T-shirt assets are `team_Work_makes_the_Dream_Work_-_front_w5qdnb` / `team_work_makes_the_dream_work_-_back_onanux`.

API-only normalization that dropped the empty string still returned the invalid hoodie ID, so images still did not load.

## Fix

On inventory-service startup (`initDb`):

- Strip empty strings from `image_urls` JSONB arrays
- Restore canonical Cloudinary public IDs for catalog products 1–8 when rows contain empty array elements or the known invalid `mirrord-hoodie` demo edit

On read (`GET /products`, `GET /products/:id`):

- Return `image_urls` with only non-empty strings; set `image_url` to the first valid entry

## Verification

- `npm --prefix apps/shop/inventory-service run lint` and `run build` pass
- After repair, `GET https://playground.metalbear.dev/shop/api/products/2` returns valid front/back shirt IDs
- Cloudinary returns 200 for `team_Work_makes_the_Dream_Work_-_front_w5qdnb`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b76846e5-8048-4871-9687-dd303be50512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b76846e5-8048-4871-9687-dd303be50512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

