### PR TITLE
Require Playwright validation in mirrord-run-shop skill

### DIFF
--- a/.claude/commands/mirrord-run.md
+++ b/.claude/commands/mirrord-run.md
@@ -63,7 +63,7 @@ tail -n 40 /tmp/mirrord-run/<service>.log
 
 If readiness regex never matches within ~3 minutes, surface the last 60 lines of the log and stop — most failures are: wrong kube context, target deployment missing, mirrord operator not authorized, or a `DATABASE_URL` mismatch.
 
-## Phase 5 — Verify the steal works
+## Phase 5 — Verify the steal works (curl)
 
 Hit staging through the public URL with the routing header, confirming the response shows the developer's local code path:
 
@@ -77,6 +77,17 @@ Pick an endpoint that actually exercises the change (the developer just told you
 
 If the response shows the **old** behavior, the request didn't get stolen. Most common causes: wrong `USER` value, header name typo, or the steal `http_filter` in `mirrord.json` is more restrictive than expected. Re-read the `header_filter` from `mirrord.json` and adapt the curl command.
 
+## Phase 5b — Verify the shop UI (Playwright) — required for catalog / image changes
+
+`curl` is not sufficient when the change affects product data the UI renders (e.g. `image_urls`, catalogue fields). Follow `.cursor/skills/mirrord-run-shop/SKILL.md`:
+
+1. Install Playwright under `/tmp/mirrord-run-shop/` (once per session).
+2. Write and run `e2e.js` with `extraHTTPHeaders: { baggage: 'mirrord-session=' + $USER }`.
+3. Assert API rows have no empty `image_urls[0]`, and that `/shop/products` and affected detail pages show loaded images (`naturalWidth > 0`, no `No image` tiles).
+4. Review screenshots in `/tmp/screenshots/mirrord-run-*.png`.
+
+**Never** run ad-hoc `kubectl exec` SQL against the shared playground database to fix or test data. Validate only through mirrord + public shop URLs.
+
 ## Phase 6 — Hand off to the developer
 
 Print exactly this block, with values filled in:
@@ -87,6 +98,7 @@ Print exactly this block, with values filled in:
 Local log:   /tmp/mirrord-run/<service>.log
 Routing:     baggage: mirrord-session=<USER>
 Quick check: curl -H "baggage: mirrord-session=<USER>" https://playground.metalbear.dev/shop/api/<endpoint>
+Playwright:  /tmp/screenshots/mirrord-run-results.json (see mirrord-run-shop skill)
 
 To see it in the browser, install the mirrord Browser Extension and set
 the same baggage header — only your requests will hit the local process.

--- a/.cursor/rules/00-mirrord-inventory-service.mdc
+++ b/.cursor/rules/00-mirrord-inventory-service.mdc
@@ -137,3 +137,5 @@ target, filter, and request path before changing product code.
 - A filtered request to `https://playground.metalbear.dev/shop/api/products...` with `baggage: mirrord-session=<MIRRORD_SESSION>` reaches the local service.
 - An unfiltered request to the same public endpoint does not reach the local service.
 - The changed inventory behavior is verified through the public shop path and the local mirrord process.
+- Run the Playwright checks in `.cursor/skills/mirrord-run-shop/SKILL.md` (API `image_urls` sanity + product images load on `/shop/products` and affected detail pages). Review screenshots; do not mark verified on `curl` alone.
+- Never mutate the shared playground database with ad-hoc SQL; validate only via mirrord + public shop traffic.

--- a/.cursor/skills/mirrord-run-shop/SKILL.md
+++ b/.cursor/skills/mirrord-run-shop/SKILL.md
@@ -1,9 +1,247 @@
 ---
 name: mirrord-run-shop
-description: REQUIRED before completing any inventory-service (or shop product API) change. Run the service under mirrord against playground GKE and verify via filtered public shop traffic.
+description: Use when running one MetalMart shop service locally under mirrord against the playground GKE cluster. Requires Playwright UI verification for catalog or frontend-affecting changes — not curl alone.
 ---
 
 # Mirrord Run Shop
 
-Use the workflow in `.cursor/rules/mirrord-inventory-service.mdc` before completing inventory-service
-or shop product API changes.
+Use this for the local inner loop against https://playground.metalbear.dev/shop.
+
+`curl` alone is not enough to mark shop or inventory work verified. Playwright catches UI failures (broken product images, empty `image_urls[0]`, layout regressions) that API JSON checks miss.
+
+For the full PR → preview-build → agent iteration loop, use `mirrord-agent-shop` instead.
+
+## Service Map
+
+- inventory, inventory-service: `apps/shop/inventory-service`
+- order, order-service: `apps/shop/order-service`
+- payment, payment-service: `apps/shop/payment-service`
+- delivery, delivery-service: `apps/shop/delivery-service`
+- receipt, receipt-service: `apps/shop/receipt-service`
+- frontend, shop, metal-mart-frontend: `apps/shop/metal-mart-frontend`
+
+## Checks Before Start
+
+```bash
+mirrord --version
+kubectl config current-context
+kubectl -n shop get deploy <deployment>
+ls apps/shop/<service>/mirrord.json
+```
+
+The kube context must be `gke_playground-383912_us-central1-c_playground-cluster-1`.
+
+Set a stable session for the whole run:
+
+```bash
+export MIRRORD_SESSION="${MIRRORD_SESSION:-${USER:-cursor-shop}}"
+```
+
+## Run Under mirrord
+
+Use absolute paths; `mirrord exec` must be the leading command:
+
+```bash
+mkdir -p /tmp/mirrord-run
+USER="$MIRRORD_SESSION" \
+  mirrord exec -f /workspace/playground/apps/shop/<service>/mirrord.json -- \
+  npm --prefix /workspace/playground/apps/shop/<service> run dev
+```
+
+Route only your traffic with:
+
+```text
+baggage: mirrord-session=${MIRRORD_SESSION}
+```
+
+Do not widen `http_filter` in `mirrord.json` to make a test pass.
+
+## Verify Traffic Is Stolen (curl)
+
+Confirm filtered traffic hits the local process and unfiltered traffic does not (see `.cursor/rules/00-mirrord-inventory-service.mdc` for inventory).
+
+```bash
+curl -sS -H "baggage: mirrord-session=${MIRRORD_SESSION}" \
+  https://playground.metalbear.dev/shop/api/products | jq '.[0:3] | .[] | {id, name, image_urls}'
+
+curl -sS https://playground.metalbear.dev/shop/api/products | jq '.[0] | {id, name}'
+```
+
+Check the local service log for the filtered request; confirm the unfiltered request does **not** appear locally.
+
+## Verify the Shop UI (Playwright) — required
+
+Run Playwright after mirrord is up whenever the change affects products, images, catalog APIs, or anything the shop UI renders.
+
+**Never** mutate the shared playground Postgres (or any cluster DB) to “verify” or “fix” data. Validate through the public shop path with mirrord + baggage only. Repair logic belongs in service code on your branch, not in ad-hoc `kubectl exec` SQL.
+
+### Install once per session
+
+```bash
+mkdir -p /tmp/mirrord-run-shop && cd /tmp/mirrord-run-shop
+[ -f package.json ] || npm init -y >/dev/null
+[ -d node_modules/playwright ] || npm install --save-dev playwright >/dev/null
+npx playwright install chromium --with-deps
+mkdir -p /tmp/screenshots
+rm -f /tmp/mirrord-run-shop/e2e.js /tmp/screenshots/mirrord-run-*
+```
+
+### Write `/tmp/mirrord-run-shop/e2e.js`
+
+Adapt checks to the change. Keep this baseline for inventory / product-image work:
+
+```js
+const { chromium } = require("playwright");
+const fs = require("fs");
+
+(async () => {
+  const session = process.env.MIRRORD_SESSION;
+  if (!session) {
+    console.error("Set MIRRORD_SESSION");
+    process.exit(1);
+  }
+  const baggage = `mirrord-session=${session}`;
+  const shopUrl = "https://playground.metalbear.dev/shop";
+  const shotsDir = "/tmp/screenshots";
+  const results = { session, checks: [], screenshots: [] };
+
+  const check = (name, ok, detail = "") => {
+    results.checks.push({ name, ok, detail });
+    console.log(`${ok ? "PASS" : "FAIL"} ${name}${detail ? ` — ${detail}` : ""}`);
+  };
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    extraHTTPHeaders: { baggage },
+  });
+  const page = await context.newPage();
+
+  const assertImgLoaded = async (locator, label) => {
+    await locator.first().waitFor({ state: "visible", timeout: 20000 });
+    const info = await locator.first().evaluate((img) => ({
+      complete: img.complete,
+      naturalWidth: img.naturalWidth,
+      src: img.currentSrc || img.src,
+    }));
+    const ok = info.complete && info.naturalWidth > 0;
+    check(`${label} image loaded`, ok, JSON.stringify(info));
+    return ok;
+  };
+
+  try {
+    // --- API: catch malformed image_urls (e.g. leading "") ---
+    const productsRes = await page.request.get(`${shopUrl}/api/products`, {
+      headers: { baggage },
+    });
+    const products = await productsRes.json();
+    check("GET /api/products", productsRes.ok(), `status ${productsRes.status()}`);
+
+    const badImageRows = (Array.isArray(products) ? products : []).filter((p) => {
+      const urls = p.image_urls;
+      if (!Array.isArray(urls) || urls.length === 0) return false;
+      const first = urls[0];
+      return typeof first !== "string" || first.trim() === "";
+    });
+    check(
+      "no product has empty image_urls[0]",
+      badImageRows.length === 0,
+      badImageRows.length
+        ? `ids=${badImageRows.map((p) => p.id).join(",")} urls=${JSON.stringify(badImageRows[0].image_urls)}`
+        : `checked ${products.length} products`
+    );
+
+    const p2Res = await page.request.get(`${shopUrl}/api/products/2`, { headers: { baggage } });
+    const p2 = await p2Res.json();
+    check("GET /api/products/2", p2Res.ok(), `status ${p2Res.status()}`);
+    const p2first = Array.isArray(p2.image_urls) ? p2.image_urls[0] : null;
+    check(
+      "product 2 image_urls[0] usable",
+      typeof p2first === "string" && p2first.trim().length > 0,
+      `image_urls=${JSON.stringify(p2.image_urls)} image_url=${p2.image_url}`
+    );
+
+    // --- UI: product list + detail images actually render ---
+    await page.goto(`${shopUrl}/products`, {
+      waitUntil: "domcontentloaded",
+      timeout: 30000,
+    });
+    await page.waitForLoadState("networkidle", { timeout: 30000 }).catch(() => {});
+
+    const noImageTiles = await page.getByText("No image", { exact: true }).count();
+    check("products grid has no 'No image' tiles", noImageTiles === 0, `count=${noImageTiles}`);
+
+    const gridImgs = page.locator('a[href*="/products/"] img');
+    const gridCount = await gridImgs.count();
+    check("products grid shows images", gridCount > 0, `img count=${gridCount}`);
+    if (gridCount > 0) await assertImgLoaded(gridImgs, "products grid");
+
+    const p2Path = `${shopUrl}/products/2`;
+    await page.screenshot({ path: `${shotsDir}/mirrord-run-products.png`, fullPage: true });
+    results.screenshots.push(`${shotsDir}/mirrord-run-products.png`);
+
+    await page.goto(p2Path, { waitUntil: "domcontentloaded", timeout: 30000 });
+    await page.waitForLoadState("networkidle", { timeout: 30000 }).catch(() => {});
+
+    const detailNoImage = await page.getByText("No image", { exact: true }).count();
+    check("product 2 detail has no 'No image' placeholder", detailNoImage === 0, `count=${detailNoImage}`);
+
+    const heroImg = page.locator(".aspect-square img");
+    if ((await heroImg.count()) > 0) {
+      await assertImgLoaded(heroImg, "product 2 detail hero");
+    } else {
+      check("product 2 detail hero image present", false, "no .aspect-square img found");
+    }
+
+    await page.screenshot({ path: `${shotsDir}/mirrord-run-product-2.png`, fullPage: true });
+    results.screenshots.push(`${shotsDir}/mirrord-run-product-2.png`);
+  } catch (err) {
+    check("fatal", false, err.message || String(err));
+    try {
+      await page.screenshot({ path: `${shotsDir}/mirrord-run-fatal.png`, fullPage: true });
+      results.screenshots.push(`${shotsDir}/mirrord-run-fatal.png`);
+    } catch {}
+  } finally {
+    await browser.close();
+    fs.writeFileSync("/tmp/screenshots/mirrord-run-results.json", JSON.stringify(results, null, 2));
+    const allOk = results.checks.every((c) => c.ok);
+    console.log(`\n${results.checks.filter((c) => c.ok).length}/${results.checks.length} checks passed`);
+    process.exit(allOk ? 0 : 1);
+  }
+})();
+```
+
+### Run Playwright
+
+```bash
+cd /tmp/mirrord-run-shop
+MIRRORD_SESSION="${MIRRORD_SESSION}" node e2e.js
+cat /tmp/screenshots/mirrord-run-results.json
+```
+
+### Review screenshots
+
+Use the image-reading tool on every PNG under `/tmp/screenshots/mirrord-run-*.png`. A visual failure (broken image icon, wrong product photo, empty tile) counts as a failed verification even if a narrow assertion passed.
+
+## Completion Criteria
+
+Do not mark shop or inventory work verified until all of the following hold:
+
+- `npm --prefix apps/shop/<service> run lint` or `run build` passes for touched services
+- Filtered public requests reach the local mirrord process; unfiltered requests do not
+- Playwright exits 0 with the checks above (adapted if the change scope differs)
+- Screenshots reviewed; product images visibly load on `/shop/products` and affected detail pages
+- No unauthorized writes to shared cluster databases
+
+## Inventory-Specific
+
+For `inventory-service`, also follow `.cursor/rules/00-mirrord-inventory-service.mdc` and `.cursor/rules/01-no-staging-api-without-mirrord.mdc`.
+
+## Handoff Block
+
+```
+✓ <service> running under mirrord (session: ${MIRRORD_SESSION})
+  Log: check terminal / tmux session
+  Header: baggage: mirrord-session=${MIRRORD_SESSION}
+  Playwright: /tmp/screenshots/mirrord-run-results.json
+  Screenshots: /tmp/screenshots/mirrord-run-products.png, mirrord-run-product-2.png
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,13 @@ Use this file and `docs/` for project context when working in this repo.
 - Do not call playground/staging shop APIs without mirrord: `.cursor/rules/01-no-staging-api-without-mirrord.mdc`.
 - For inventory-service changes, use the mirrord filtered-traffic workflow in `.cursor/rules/00-mirrord-inventory-service.mdc`.
 
+## Playground / staging guardrails
+
+The shared cluster at `https://playground.metalbear.dev` is staging. When verifying or fixing shop work:
+
+- **Do not use `kubectl port-forward`** (or similar) into `shop` or `infra` workloads as a substitute for mirrord or local-only testing. Use `mirrord exec` with the service `mirrord.json` and session-filtered traffic through the public shop URL, or run services locally (see `.cursor/skills/mirrord-run-shop/SKILL.md`).
+- **Do not alter the playground/staging database** without explicit human permission. No ad-hoc `kubectl exec` into Postgres, no manual `UPDATE`/`INSERT`/`DELETE` against shared `inventory`, `orders`, or other demo DBs to “fix” or “test” data. Validate through mirrord + public APIs and Playwright; put repairs in service code on your branch if data must be normalized at runtime.
+
 ## Build and deploy
 
 - **GKE:** `kubectl apply -k overlays/gke` (or `kustomize build --enable-helm overlays/gke | kubectl apply -f -`). See [docs/AI_ROOT_CONTEXT.md](docs/AI_ROOT_CONTEXT.md) and `overlays/gke/DRY-RUN.md` if present.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the `mirrord-run-shop` skill so agents verify catalog and image changes with Playwright, not `curl` alone. Documents staging guardrails in `AGENTS.md`.

## Changes

- **`.cursor/skills/mirrord-run-shop/SKILL.md`**: Playwright install/run steps, reusable `e2e.js` template (API `image_urls` checks + image load assertions), screenshot review, ban on ad-hoc shared DB writes
- **`.claude/commands/mirrord-run.md`**: Phase 5b pointing at the skill
- **`.cursor/rules/00-mirrord-inventory-service.mdc`**: Inventory completion requires Playwright per the skill
- **`AGENTS.md`**: New “Playground / staging guardrails” — no `kubectl port-forward` for verification; no altering playground/staging DB without explicit permission

## How agents should use it

1. Start service under mirrord with `MIRRORD_SESSION` set
2. Confirm steal with filtered/unfiltered `curl`
3. Run `/tmp/mirrord-run-shop/e2e.js` with the baggage header
4. Review `/tmp/screenshots/mirrord-run-*.png` before marking work verified
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b76846e5-8048-4871-9687-dd303be50512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b76846e5-8048-4871-9687-dd303be50512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

