### PR TITLE
Fix product 2 image not loading in shop UI

### DIFF
--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -13,6 +13,36 @@ if (dbUrl && !/:\d+\/.+$/.test(dbUrl)) {
 
 const pool = new Pool({ connectionString: dbUrl });
 
+const PRODUCT_2_IMAGE_URLS = [
+  "team_Work_makes_the_Dream_Work_-_front_w5qdnb",
+  "team_work_makes_the_dream_work_-_back_onanux",
+];
+
+type ProductRow = {
+  id: number;
+  name: string;
+  description: string | null;
+  price_cents: number;
+  stock: number;
+  image_url: string | null;
+  image_urls: string[] | null;
+  is_new: boolean;
+};
+
+/** Drop blank entries; prefer image_urls, fall back to legacy image_url. */
+function sanitizeProduct(row: ProductRow): ProductRow {
+  const fromArray = Array.isArray(row.image_urls)
+    ? row.image_urls.filter((u): u is string => typeof u === "string" && u.trim().length > 0)
+    : [];
+  const image_urls =
+    fromArray.length > 0
+      ? fromArray
+      : row.image_url?.trim()
+        ? [row.image_url.trim()]
+        : [];
+  return { ...row, image_urls, image_url: image_urls[0] ?? null };
+}
+
 async function initDb() {
   const client = await pool.connect();
   try {
@@ -51,6 +81,21 @@ async function initDb() {
       UPDATE products SET image_urls = jsonb_build_array(image_url)
       WHERE (image_urls IS NULL OR image_urls = '[]'::jsonb) AND image_url IS NOT NULL
     `);
+    // Repair product 2 when image_urls were corrupted (empty slot or invalid sample path).
+    await client.query(
+      `UPDATE products
+       SET image_urls = $1::jsonb, image_url = NULL
+       WHERE id = 2
+         AND (
+           EXISTS (SELECT 1 FROM jsonb_array_elements_text(image_urls) elem WHERE trim(elem) = '')
+           OR image_url ILIKE '%mirrord-hoodie-front%'
+           OR EXISTS (
+             SELECT 1 FROM jsonb_array_elements_text(image_urls) elem
+             WHERE elem ILIKE '%mirrord-hoodie-front%'
+           )
+         )`,
+      [JSON.stringify(PRODUCT_2_IMAGE_URLS)]
+    );
   } finally {
     client.release();
   }
@@ -72,8 +117,10 @@ app.get("/health", (_req, res) => {
 app.get("/products", async (_req, res) => {
   // Set a breakpoint here; trigger with: curl http://localhost:28080/products -H "X-PG-Tenant: dev" (while port-forward + mirrord are running)
   try {
-    const { rows } = await pool.query("SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id");
-    res.json(rows);
+    const { rows } = await pool.query<ProductRow>(
+      "SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id"
+    );
+    res.json(rows.map(sanitizeProduct));
   } catch (err) {
     console.error("Error fetching products:", err);
     res.status(500).json({ error: "Internal server error" });
@@ -86,14 +133,14 @@ app.get("/products/:id", async (req, res) => {
     return res.status(400).json({ error: "Invalid product ID" });
   }
   try {
-    const { rows } = await pool.query(
+    const { rows } = await pool.query<ProductRow>(
       "SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products WHERE id = $1",
       [id]
     );
     if (rows.length === 0) {
       return res.status(404).json({ error: "Product not found" });
     }
-    res.json(rows[0]);
+    res.json(sanitizeProduct(rows[0]));
   } catch (err) {
     console.error("Error fetching product:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/apps/shop/metal-mart-frontend/src/lib/product.ts
+++ b/apps/shop/metal-mart-frontend/src/lib/product.ts
@@ -10,17 +10,23 @@ export type Product = {
   is_new?: boolean;
 };
 
+function nonEmptyImageUrls(urls: (string | null | undefined)[] | null | undefined): string[] {
+  if (!urls?.length) return [];
+  return urls.filter((u): u is string => typeof u === "string" && u.trim().length > 0);
+}
+
 /** Primary image for thumbnails (first in array, or legacy image_url). */
 export function getPrimaryImageUrl(product: Product): string | null {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls[0];
-  return product.image_url ?? null;
+  const urls = nonEmptyImageUrls(product.image_urls);
+  if (urls.length > 0) return urls[0];
+  const legacy = product.image_url?.trim();
+  return legacy || null;
 }
 
 /** All image URLs for product (front, back, etc.). */
 export function getImageUrls(product: Product): string[] {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls;
-  const single = product.image_url;
+  const urls = nonEmptyImageUrls(product.image_urls);
+  if (urls.length > 0) return urls;
+  const single = product.image_url?.trim();
   return single ? [single] : [];
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Product 2 (Team Work t-shirt) failed to show images because `image_urls` in inventory contained an empty first entry and an invalid Cloudinary path (`Metal Mart/samples/mirrord-hoodie-front`).

## Changes

- **inventory-service**: On startup, repair product 2 when corrupted image data is detected; sanitize API responses to drop blank `image_urls` entries and derive a consistent primary `image_url`.
- **metal-mart-frontend**: Ignore empty strings in `getPrimaryImageUrl` / `getImageUrls` so thumbnails never try to render a blank `src`.

## Verification

- `npm --prefix apps/shop/inventory-service run build`
- mirrord + filtered `curl` to `https://playground.metalbear.dev/shop/api/products/2` returns valid `image_urls`
- Playwright on `/shop/products/2` with session baggage: main image and thumbnails load from Cloudinary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0ef946a-c31b-4ef1-88c9-867b98fa21a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0ef946a-c31b-4ef1-88c9-867b98fa21a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

