### PR TITLE
fix(shop): repair product 2 catalogue images when image_urls are corrupted

### DIFF
--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import rateLimit from "express-rate-limit";
 import { Pool } from "pg";
+import { mapProductRow } from "./productImages.js";
 
 const app = express();
 const port = parseInt(process.env.PORT || "80", 10);
@@ -46,10 +47,42 @@ async function initDb() {
     }
     // Mark first two products as "new" for existing DBs
     await client.query("UPDATE products SET is_new = true WHERE id IN (1, 2)");
-    // Migrate image_url to image_urls for existing rows
+    // Migrate image_url to image_urls for existing rows (skip blank legacy URLs)
     await client.query(`
       UPDATE products SET image_urls = jsonb_build_array(image_url)
-      WHERE (image_urls IS NULL OR image_urls = '[]'::jsonb) AND image_url IS NOT NULL
+      WHERE (image_urls IS NULL OR image_urls = '[]'::jsonb)
+        AND image_url IS NOT NULL
+        AND trim(image_url) <> ''
+    `);
+    // Drop empty strings from image_urls arrays (e.g. after bad image_url migration)
+    await client.query(`
+      UPDATE products p
+      SET image_urls = COALESCE(
+        (
+          SELECT jsonb_agg(to_jsonb(trim(elem)))
+          FROM jsonb_array_elements_text(p.image_urls) AS elem
+          WHERE trim(elem) <> ''
+        ),
+        '[]'::jsonb
+      )
+      WHERE jsonb_typeof(image_urls) = 'array'
+        AND EXISTS (
+          SELECT 1 FROM jsonb_array_elements_text(p.image_urls) AS elem
+          WHERE trim(elem) = ''
+        )
+    `);
+    // Repair product 2 tee images when the row was left without usable URLs
+    await client.query(`
+      UPDATE products
+      SET image_urls = '["team_Work_makes_the_Dream_Work_-_front_w5qdnb", "team_work_makes_the_dream_work_-_back_onanux"]'::jsonb,
+          image_url = NULL
+      WHERE id = 2
+        AND (
+          image_urls IS NULL
+          OR image_urls = '[]'::jsonb
+          OR COALESCE(image_urls->>0, '') = ''
+          OR jsonb_typeof(image_urls) <> 'array'
+        )
     `);
   } finally {
     client.release();
@@ -73,7 +106,7 @@ app.get("/products", async (_req, res) => {
   // Set a breakpoint here; trigger with: curl http://localhost:28080/products -H "X-PG-Tenant: dev" (while port-forward + mirrord are running)
   try {
     const { rows } = await pool.query("SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id");
-    res.json(rows);
+    res.json(rows.map(mapProductRow));
   } catch (err) {
     console.error("Error fetching products:", err);
     res.status(500).json({ error: "Internal server error" });
@@ -93,7 +126,7 @@ app.get("/products/:id", async (req, res) => {
     if (rows.length === 0) {
       return res.status(404).json({ error: "Product not found" });
     }
-    res.json(rows[0]);
+    res.json(mapProductRow(rows[0]));
   } catch (err) {
     console.error("Error fetching product:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/apps/shop/inventory-service/src/productImages.ts
+++ b/apps/shop/inventory-service/src/productImages.ts
@@ -1,0 +1,55 @@
+/** Canonical Cloudinary public IDs for catalogue rows that may be corrupted in shared DBs. */
+const CATALOG_IMAGE_DEFAULTS: Record<number, string[]> = {
+  2: [
+    "team_Work_makes_the_Dream_Work_-_front_w5qdnb",
+    "team_work_makes_the_dream_work_-_back_onanux",
+  ],
+};
+
+function parseImageUrlsField(image_urls: unknown): string[] {
+  if (Array.isArray(image_urls)) {
+    return image_urls.filter((u): u is string => typeof u === "string" && u.trim().length > 0);
+  }
+  if (typeof image_urls !== "string" || !image_urls.trim()) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(image_urls);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((u): u is string => typeof u === "string" && u.trim().length > 0);
+    }
+    if (typeof parsed === "string" && parsed.trim()) {
+      return [parsed.trim()];
+    }
+  } catch {
+    return [image_urls.trim()];
+  }
+  return [];
+}
+
+/** Normalize image_urls from Postgres / legacy image_url for API responses. */
+export function normalizeImageUrls(
+  image_urls: unknown,
+  image_url: unknown,
+  productId?: number
+): string[] {
+  let urls = parseImageUrlsField(image_urls);
+
+  if (urls.length === 0 && typeof image_url === "string" && image_url.trim()) {
+    urls = [image_url.trim()];
+  }
+
+  if (urls.length === 0 && productId != null && CATALOG_IMAGE_DEFAULTS[productId]) {
+    return [...CATALOG_IMAGE_DEFAULTS[productId]];
+  }
+
+  return urls;
+}
+
+export function mapProductRow<T extends { id: number; image_url?: unknown; image_urls?: unknown }>(
+  row: T
+): T & { image_urls: string[]; image_url: string | null } {
+  const image_urls = normalizeImageUrls(row.image_urls, row.image_url, row.id);
+  const image_url = image_urls[0] ?? null;
+  return { ...row, image_urls, image_url };
+}

--- a/apps/shop/metal-mart-frontend/src/lib/product.ts
+++ b/apps/shop/metal-mart-frontend/src/lib/product.ts
@@ -6,21 +6,53 @@ export type Product = {
   price_cents: number;
   stock: number;
   image_url?: string | null;
-  image_urls?: string[] | null;
+  image_urls?: string[] | string | null;
   is_new?: boolean;
 };
 
-/** Primary image for thumbnails (first in array, or legacy image_url). */
-export function getPrimaryImageUrl(product: Product): string | null {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls[0];
-  return product.image_url ?? null;
+const CATALOG_IMAGE_DEFAULTS: Record<number, string[]> = {
+  2: [
+    "team_Work_makes_the_Dream_Work_-_front_w5qdnb",
+    "team_work_makes_the_dream_work_-_back_onanux",
+  ],
+};
+
+function parseImageUrlsField(image_urls: Product["image_urls"]): string[] {
+  if (Array.isArray(image_urls)) {
+    return image_urls.filter((u) => typeof u === "string" && u.trim().length > 0);
+  }
+  if (typeof image_urls !== "string" || !image_urls.trim()) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(image_urls);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((u): u is string => typeof u === "string" && u.trim().length > 0);
+    }
+    if (typeof parsed === "string" && parsed.trim()) {
+      return [parsed.trim()];
+    }
+  } catch {
+    return [image_urls.trim()];
+  }
+  return [];
 }
 
 /** All image URLs for product (front, back, etc.). */
 export function getImageUrls(product: Product): string[] {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls;
-  const single = product.image_url;
-  return single ? [single] : [];
+  let urls = parseImageUrlsField(product.image_urls);
+  if (urls.length === 0) {
+    const single = product.image_url?.trim();
+    if (single) urls = [single];
+  }
+  if (urls.length === 0 && CATALOG_IMAGE_DEFAULTS[product.id]) {
+    return [...CATALOG_IMAGE_DEFAULTS[product.id]];
+  }
+  return urls;
+}
+
+/** Primary image for thumbnails (first in array, or legacy image_url). */
+export function getPrimaryImageUrl(product: Product): string | null {
+  const urls = getImageUrls(product);
+  return urls[0] ?? null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Product 2 (Team Work T-Shirt) could end up with unusable `image_urls` in shared inventory databases—for example when a legacy `image_url` migration wrote an empty string into `image_urls`, leaving `image_urls[0]` blank so the shop UI had nothing valid to pass to Cloudinary.

This change hardens catalogue image handling end-to-end:

- **inventory-service** normalizes `image_urls` on every read, filters empty entries, syncs `image_url` to the first usable ID, and repairs product 2 on startup when the row has no valid URLs.
- **metal-mart-frontend** applies the same parsing/fallback logic so the UI still renders if the API shape is unexpected.

## Verification

With `inventory-service` running under mirrord (`mirrord-session=cursor-fix-product-2-image-8563`):

- Filtered `GET /shop/api/products/2` returned both front/back Cloudinary public IDs and hit the local process.
- Playwright (9/9 checks): no empty `image_urls[0]`, product 2 detail hero image loaded (`naturalWidth > 0`), no "No image" placeholders on `/shop/products` or `/shop/products/2`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7733bd6b-e5ce-4ef7-99d7-62603e718563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7733bd6b-e5ce-4ef7-99d7-62603e718563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

