### PR TITLE
Fix product detail gallery image loading

### DIFF
--- a/apps/shop/metal-mart-frontend/src/app/products/[id]/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/[id]/page.tsx
@@ -83,6 +83,7 @@ export default function ProductDetailPage() {
                     className="h-full w-full object-cover"
                     fill
                     sizes="(max-width: 768px) 100vw, 50vw"
+                    priority
                   />
                 ) : (
                   <div className="flex h-full w-full items-center justify-center text-slate-400">

--- a/apps/shop/metal-mart-frontend/src/components/ProductImage.tsx
+++ b/apps/shop/metal-mart-frontend/src/components/ProductImage.tsx
@@ -43,6 +43,7 @@ export default function ProductImage({
   if (useCloudinary) {
     return (
       <CldImage
+        key={src}
         src={resolveCloudinaryId(src)}
         alt={alt}
         className={className}
@@ -57,6 +58,13 @@ export default function ProductImage({
 
   return (
     // eslint-disable-next-line @next/next/no-img-element
-    <img src={src} alt={alt} className={className} />
+    <img
+      key={src}
+      src={src}
+      alt={alt}
+      className={className}
+      loading={priority ? "eager" : "lazy"}
+      fetchPriority={priority ? "high" : undefined}
+    />
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remount Cloudinary/full-URL product images when the image source changes.
- Mark the selected product detail gallery image as priority so product 2's alternate image loads reliably after switching thumbnails.
- Apply eager/high-priority loading behavior to full-URL image fallbacks when priority is requested.

## Verification
- `NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=dxas4fpir npm --prefix apps/shop/metal-mart-frontend run build`
- `npm --prefix apps/shop/metal-mart-frontend run lint` *(fails: existing ESLint 9 setup has no `eslint.config.*` flat config)*
- mirrord filtered public API check for `/shop/api/products/2` returned product 2 `image_urls` and reached local `inventory-service` with `mirrord-key: cursor-image`
- unfiltered public API check for `/shop/api/products/2` returned the same data and did not produce a matching local `/products/2` mirrord log
- Playwright against local built frontend (`http://localhost:3000`) verified product 2 list image and selected Back detail image load with nonzero natural dimensions

## Screenshots
- `/tmp/screenshots/product-2-list.png`
- `/tmp/screenshots/product-2-detail.png`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38d2a457-5a20-46f3-9091-fefccb554788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38d2a457-5a20-46f3-9091-fefccb554788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

