### PR TITLE
Fix blank product image fallback

### DIFF
--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -13,6 +13,49 @@ if (dbUrl && !/:\d+\/.+$/.test(dbUrl)) {
 
 const pool = new Pool({ connectionString: dbUrl });
 
+type ProductRow = {
+  id: number;
+  image_url: string | null;
+  image_urls: unknown;
+};
+
+type ProductResponse<T extends ProductRow> = Omit<T, "image_url" | "image_urls"> & {
+  image_url: string | null;
+  image_urls: string[];
+};
+
+const PRODUCT_IMAGE_REPAIRS: Record<number, string[]> = {
+  2: [
+    "team_Work_makes_the_Dream_Work_-_front_w5qdnb",
+    "team_work_makes_the_dream_work_-_back_onanux",
+  ],
+};
+
+const BROKEN_IMAGE_URLS = new Set(["Metal Mart/samples/mirrord-hoodie-front"]);
+
+function normalizeImageUrl(url: unknown): string | null {
+  if (typeof url !== "string") return null;
+  const trimmed = url.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normalizeProductImages<T extends ProductRow>(product: T): ProductResponse<T> {
+  const imageUrls = Array.isArray(product.image_urls)
+    ? product.image_urls.map(normalizeImageUrl).filter((url): url is string => url !== null)
+    : [];
+  const imageUrl = normalizeImageUrl(product.image_url);
+  const repairedUrls = PRODUCT_IMAGE_REPAIRS[product.id];
+  const hasBrokenImage =
+    imageUrls.some((url) => BROKEN_IMAGE_URLS.has(url)) ||
+    (imageUrl ? BROKEN_IMAGE_URLS.has(imageUrl) : false);
+
+  if (repairedUrls && (imageUrls.length === 0 || hasBrokenImage)) {
+    return { ...product, image_url: repairedUrls[0], image_urls: repairedUrls };
+  }
+
+  return { ...product, image_url: imageUrl, image_urls: imageUrls };
+}
+
 async function initDb() {
   const client = await pool.connect();
   try {
@@ -73,7 +116,7 @@ app.get("/products", async (_req, res) => {
   // Set a breakpoint here; trigger with: curl http://localhost:28080/products -H "X-PG-Tenant: dev" (while port-forward + mirrord are running)
   try {
     const { rows } = await pool.query("SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id");
-    res.json(rows);
+    res.json(rows.map(normalizeProductImages));
   } catch (err) {
     console.error("Error fetching products:", err);
     res.status(500).json({ error: "Internal server error" });
@@ -93,7 +136,7 @@ app.get("/products/:id", async (req, res) => {
     if (rows.length === 0) {
       return res.status(404).json({ error: "Product not found" });
     }
-    res.json(rows[0]);
+    res.json(normalizeProductImages(rows[0]));
   } catch (err) {
     console.error("Error fetching product:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/apps/shop/metal-mart-frontend/src/lib/product.ts
+++ b/apps/shop/metal-mart-frontend/src/lib/product.ts
@@ -12,15 +12,21 @@ export type Product = {
 
 /** Primary image for thumbnails (first in array, or legacy image_url). */
 export function getPrimaryImageUrl(product: Product): string | null {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls[0];
-  return product.image_url ?? null;
+  return getImageUrls(product)[0] ?? null;
 }
 
 /** All image URLs for product (front, back, etc.). */
 export function getImageUrls(product: Product): string[] {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls;
-  const single = product.image_url;
+  const urls = (product.image_urls ?? [])
+    .map(normalizeImageUrl)
+    .filter((url): url is string => url !== null);
+  if (urls.length > 0) return urls;
+
+  const single = normalizeImageUrl(product.image_url);
   return single ? [single] : [];
+}
+
+function normalizeImageUrl(url: string | null | undefined): string | null {
+  const trimmed = url?.trim();
+  return trimmed ? trimmed : null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Ignore blank strings in frontend product image helpers before rendering shop images.
- Normalize inventory product image responses and repair product id 2's stale blank/broken image values to valid Team Work front/back Cloudinary IDs.
- Avoids ad-hoc shared DB mutation; the repair is applied on the inventory read path.

## Testing
- `npm --prefix apps/shop/inventory-service run build` ✅
- `npx tsc --noEmit` in `apps/shop/metal-mart-frontend` ✅
- `NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=dxas4fpir npx next build --experimental-build-mode compile` ✅
- `npm --prefix apps/shop/metal-mart-frontend run lint` ⚠️ blocked by existing app config issue: ESLint 9 cannot find `eslint.config.*`
- mirrord-filtered public API checks against `https://playground.metalbear.dev/shop/api/products/2` ✅
  - filtered response returns repaired `image_urls`
  - unfiltered response remains stale and did not hit local inventory logs
- Public Playwright checks with `baggage: mirrord-session=product-image-9d4a` ✅
  - API exposes repaired product 2 image array
  - `/shop/products` renders product 2 image
  - `/shop/products/2` renders product 2 image

## Screenshots
- Products grid: `/tmp/screenshots/iter12-products.png`
- Product 2 detail: `/tmp/screenshots/iter12-product-2.png`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f803f7c-9f17-4184-bc11-ac04c7ad9d4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f803f7c-9f17-4184-bc11-ac04c7ad9d4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

