### PR TITLE
Append test-070626 to order confirmed status response

### DIFF
--- a/apps/shop/order-service/src/index.ts
+++ b/apps/shop/order-service/src/index.ts
@@ -121,7 +121,7 @@ class OrderError extends Error {
 /** Create order via direct path: inventory → payment → DB → Kafka. */
 async function createOrderDirect(
   input: OrderInput
-): Promise<{ orderId: number; status: string }> {
+): Promise<{ orderId: number; status: string; message: string }> {
   const { items, total_cents: totalCents, customer_email, baggage } = input;
 
   for (const item of items) {
@@ -225,7 +225,7 @@ async function createOrderDirect(
     baggage,
   });
 
-  return { orderId, status: "confirmed test-070626" };
+  return { orderId, status: "confirmed", message: "test-070626" };
 }
 
 app.post("/orders", async (req, res) => {

--- a/apps/shop/order-service/src/index.ts
+++ b/apps/shop/order-service/src/index.ts
@@ -225,7 +225,7 @@ async function createOrderDirect(
     baggage,
   });
 
-  return { orderId, status: "confirmed" };
+  return { orderId, status: "confirmed test-070626" };
 }
 
 app.post("/orders", async (req, res) => {


### PR DESCRIPTION
## Summary
- Changes the `POST /orders` HTTP response from `createOrderDirect` so `status` returns `"confirmed test-070626"` instead of `"confirmed"`.

## Notes
- Only the returned response body was changed. The DB insert, Kafka, RabbitMQ, and PubSub events still write `confirmed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)