### PR TITLE
Use local mirrord for shop validation skills

### DIFF
--- a/.cursor/skills/mirrord-agent-shop/SKILL.md
+++ b/.cursor/skills/mirrord-agent-shop/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: mirrord-agent-shop
+description: Use when a developer asks for a MetalMart shop change that must be implemented and verified end-to-end with local mirrord and Playwright before handoff.
+---
+
+# Mirrord Agent Shop
+
+Use this skill when the agent must own implementation and validation for the
+MetalMart shop. This workflow is local-mirrord-only: do not dispatch or wait for
+the `preview-shop-pr.yml` workflow, and do not use `mirrord preview` as the
+agent validation path.
+
+Read `docs/AI_ROOT_CONTEXT.md` first for repo and deployment context.
+
+## Phase 1: Intake
+
+- Restate the requested change in one sentence.
+- Identify which shop services are affected:
+  - `metal-mart-frontend`
+  - `inventory-service`
+  - `order-service`
+  - `payment-service`
+  - `delivery-service`
+  - `receipt-service`
+- Classify each touched service as:
+  - `shared DB` if it uses playground Postgres or another shared backing store
+  - `no DB` if it has no database
+- If the change introduces DDL or requires shared DB mutation, stop and ask for
+  explicit human confirmation. Never mutate the shared playground database as a
+  validation shortcut.
+- Ask at most one clarifying question, and only if scope is genuinely ambiguous.
+
+## Phase 2: Write the Test Plan Before Code
+
+Write a short numbered plan with three sections:
+
+1. Functional checks
+2. Visual checks
+3. Regression guards
+
+For any `shared DB` service, data assertions must tolerate stale rows. Use one of:
+
+- Most-recent-row semantics
+- A unique per-run marker
+- `created_at >= runStart`
+
+Echo the plan briefly, do not ask for approval, and proceed unless the developer
+objects.
+
+## Phase 3: Branch, Edit, Commit, Push, PR
+
+- Create a normal feature branch that follows the active cloud-agent branch
+  requirements.
+- Edit only the touched app or service paths plus tests/helpers needed for the
+  requested validation.
+- When tests depend on changed UI, add stable `data-testid="..."` attributes in
+  the same commit as the UI change.
+- Commit and push the implementation before validation starts.
+- Open or update the PR before validation starts; update it again after any
+  validation-driven fixes.
+
+Capture:
+
+```text
+BRANCH=<branch>
+PR_URL=<url>
+MIRRORD_SESSION=<stable lowercase session key>
+```
+
+Use a session key without slashes, for example the final branch path segment with
+any unsupported characters replaced by `-`.
+
+## Phase 4: Start Local Services Under mirrord
+
+Before any request to `https://playground.metalbear.dev/shop...`, confirm the
+target and cluster:
+
+```bash
+mirrord --version
+kubectl config current-context
+kubectl -n shop get deploy <deployment>
+test "$(kubectl config current-context)" = "gke_playground-383912_us-central1-c_playground-cluster-1"
+```
+
+Start each touched backend service with its checked-in `mirrord.json`. Keep
+`mirrord exec` as the command that starts the app process; do not widen
+`http_filter` settings.
+
+### Reliable tmux pattern in this container
+
+In the Cursor Cloud base used here, `/exec-daemon/tmux.portal.conf` may be
+absent. If it is absent, use `tmux -f /dev/null`. Prefer starting the long-running
+mirrord command directly as the tmux session command; this worked reliably on the
+first attempt and avoids shell/client edge cases with `send-keys`.
+
+```bash
+SESSION_NAME="<service>-mirrord"
+MIRRORD_SESSION="<stable-session-key>"
+TMUX_CONFIG="/exec-daemon/tmux.portal.conf"
+if [ ! -f "$TMUX_CONFIG" ]; then TMUX_CONFIG="/dev/null"; fi
+
+tmux -f "$TMUX_CONFIG" kill-session -t "$SESSION_NAME" 2>/dev/null || true
+tmux -f "$TMUX_CONFIG" new-session -d -s "$SESSION_NAME" -c /workspace/playground \
+  "export MIRRORD_SESSION='$MIRRORD_SESSION'; \
+   export USER=\"\$MIRRORD_SESSION\"; \
+   mirrord exec -f /workspace/playground/apps/shop/<service>/mirrord.json -- \
+   npm --prefix /workspace/playground/apps/shop/<service> run dev"
+tmux -f "$TMUX_CONFIG" capture-pane -pt "$SESSION_NAME:0.0" -S -200
+```
+
+If follow-up input is required, use the same `-f "$TMUX_CONFIG"` value for
+`send-keys`:
+
+```bash
+tmux -f "$TMUX_CONFIG" send-keys -t "$SESSION_NAME:0.0" -l '<command>'
+tmux -f "$TMUX_CONFIG" send-keys -t "$SESSION_NAME:0.0" C-m
+```
+
+## Phase 5: Validate With Local mirrord
+
+### Backend or catalog changes
+
+Send filtered traffic through the public user-facing shop path so the request
+exercises the gateway, frontend API route, and local mirrord service:
+
+```bash
+curl -sS \
+  -H "baggage: mirrord-session=${MIRRORD_SESSION}" \
+  https://playground.metalbear.dev/shop/api/products
+```
+
+Also send one matching unfiltered request while mirrord is running and confirm it
+does not appear in the local service logs:
+
+```bash
+curl -sS https://playground.metalbear.dev/shop/api/products
+```
+
+For inventory/product-catalog changes, follow
+`.cursor/rules/00-mirrord-inventory-service.mdc` end-to-end.
+
+### Frontend changes
+
+Run `metal-mart-frontend` locally and point it at local or mirrord-backed service
+URLs. Prefer:
+
+```bash
+NEXT_BASE_PATH=/shop \
+NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=dxas4fpir \
+INVENTORY_SERVICE_URL=http://127.0.0.1:80 \
+npm --prefix /workspace/playground/apps/shop/metal-mart-frontend run dev
+```
+
+Then validate with Playwright against `http://127.0.0.1:3000/shop`. If the test
+must prove gateway/header propagation for a backend, use the public shop URL with
+`extraHTTPHeaders: { baggage: "mirrord-session=<session>" }` while the target
+backend is running under mirrord.
+
+## Phase 6: Playwright Verification
+
+Install Playwright once per session outside the repo:
+
+```bash
+mkdir -p /tmp/mirrord-agent-shop /tmp/screenshots
+[ -d /tmp/mirrord-agent-shop/node_modules/playwright ] || npm --prefix /tmp/mirrord-agent-shop install playwright
+npx --prefix /tmp/mirrord-agent-shop playwright install chromium
+rm -f /tmp/mirrord-agent-shop/e2e.js /tmp/screenshots/iter*-results.json
+```
+
+Write `/tmp/mirrord-agent-shop/e2e.js` from the Phase 2 plan. Use:
+
+- `BASE_URL`, usually `http://127.0.0.1:3000/shop` for frontend validation or
+  `https://playground.metalbear.dev/shop` for backend filtered-path validation
+- `MIRRORD_SESSION` only when sending filtered public traffic
+- one `check()` per functional assertion
+- one screenshot per visual assertion
+- stable `[data-testid="..."]` selectors for changed UI when available
+
+Run the script and save JSON results under `/tmp/screenshots/iter<n>-results.json`.
+Review every screenshot with the available image-viewing tool. A visual mismatch
+counts as failed verification even if Playwright exits 0.
+
+## Phase 7: Internal Iteration
+
+If a functional check fails, screenshot review fails, or a local service fails to
+start:
+
+1. Diagnose the root cause.
+2. First rule out shared-DB stale-data problems before changing product code.
+3. Fix the code or fix the test.
+4. Commit and push the iteration fix.
+5. Restart the local mirrord service and rerun validation.
+6. Update the PR.
+
+Internal cap: 3 attempts. If still failing, report that directly and ask for
+developer input.
+
+## Phase 8: Report Back
+
+Return one concise report containing:
+
+- One-line change summary
+- Local validation URL or public filtered URL used
+- Baggage header, if used
+- PR URL
+- Test pass count for the final iteration
+- Failed checks, if any
+- Screenshot paths with one-line observations
+- Brief iteration notes if more than one attempt was needed
+
+End with the developer choice set:
+
+- `approve`
+- `feedback`
+- `pivot`
+- `abort`
+
+## Guardrails
+
+- Never merge the PR automatically.
+- Never use the preview workflow or `mirrord preview` for this validation skill.
+- Never skip the Phase 2 test plan.
+- Never use `git push --force` or `--no-verify`.
+- Treat visual failures as real failures.
+- Never write shared-DB assertions that can pass on stale data.
+- Never use unfiltered staging responses as proof that local code works.

--- a/.cursor/skills/mirrord-agent-shop/SKILL.md
+++ b/.cursor/skills/mirrord-agent-shop/SKILL.md
@@ -86,6 +86,11 @@ Start each touched backend service with its checked-in `mirrord.json`. Keep
 `mirrord exec` as the command that starts the app process; do not widen
 `http_filter` settings.
 
+For backend or inventory validation, do **not** run `metal-mart-frontend` under
+mirrord. Leave the deployed staging frontend/gateway in the request path and
+access `https://playground.metalbear.dev/shop...` with the baggage header so the
+test shows how the local backend behaves behind the real staging frontend.
+
 ### Reliable tmux pattern in this container
 
 In the Cursor Cloud base used here, `/exec-daemon/tmux.portal.conf` may be
@@ -141,8 +146,10 @@ For inventory/product-catalog changes, follow
 
 ### Frontend changes
 
-Run `metal-mart-frontend` locally and point it at local or mirrord-backed service
-URLs. Prefer:
+Only run `metal-mart-frontend` locally when the frontend itself is changed or the
+test must exercise unreleased frontend code. Do not use a local or mirrord-backed
+frontend to prove inventory/backend behavior. For frontend changes, point API env
+vars at local or mirrord-backed service URLs. Prefer:
 
 ```bash
 NEXT_BASE_PATH=/shop \

--- a/.cursor/skills/mirrord-run-shop/SKILL.md
+++ b/.cursor/skills/mirrord-run-shop/SKILL.md
@@ -61,6 +61,12 @@ USER="$MIRRORD_SESSION" \
 
 Do not widen `http_filter` in `mirrord.json` to make a test pass.
 
+For inventory or other backend validation, do **not** run
+`metal-mart-frontend` under mirrord. Keep the deployed staging frontend/gateway
+in the request path and access `https://playground.metalbear.dev/shop...` with
+the baggage header. That proves how the local backend behaves behind the real
+staging frontend.
+
 ## Reliable tmux Pattern
 
 Use tmux for long-running mirrord services. In this Cursor Cloud base container,
@@ -206,9 +212,11 @@ const fs = require("fs");
 
 ### Frontend-local baseline
 
-For frontend-only validation, run the frontend locally and validate
-`http://127.0.0.1:3000/shop`. Point API env vars at local or mirrord-backed
-service URLs:
+For frontend-only validation, or when the frontend itself has unreleased code,
+run the frontend locally and validate `http://127.0.0.1:3000/shop`. Point API env
+vars at local or mirrord-backed service URLs. Do not use this path as proof of
+inventory/backend behavior; backend validation should use the deployed staging
+frontend and public shop URL.
 
 ```bash
 NEXT_BASE_PATH=/shop \

--- a/.cursor/skills/mirrord-run-shop/SKILL.md
+++ b/.cursor/skills/mirrord-run-shop/SKILL.md
@@ -7,9 +7,8 @@ description: Use when running one MetalMart shop service locally under mirrord a
 
 Use this for the local inner loop against `https://playground.metalbear.dev/shop`.
 
-`curl` alone is not enough to mark shop or inventory work verified. Playwright
-catches UI failures (broken product images, empty `image_urls[0]`, layout
-regressions) that API JSON checks miss.
+`curl` alone is not enough to mark shop or inventory work verified. Use
+Playwright for UI-facing checks.
 
 For full agent-owned implementation and validation, use `mirrord-agent-shop`.
 That skill also uses local mirrord; it must not use the preview workflow.
@@ -233,8 +232,7 @@ cat /tmp/screenshots/mirrord-run-results.json
 ```
 
 Review every PNG under `/tmp/screenshots/mirrord-run-*.png`. A visual failure
-(broken image icon, wrong product photo, empty tile) counts as a failed
-verification even if a narrow assertion passed.
+counts as a failed verification even if a narrow assertion passed.
 
 ## Completion Criteria
 

--- a/.cursor/skills/mirrord-run-shop/SKILL.md
+++ b/.cursor/skills/mirrord-run-shop/SKILL.md
@@ -1,15 +1,18 @@
 ---
 name: mirrord-run-shop
-description: Use when running one MetalMart shop service locally under mirrord against the playground GKE cluster. Requires Playwright UI verification for catalog or frontend-affecting changes — not curl alone.
+description: Use when running one MetalMart shop service locally under mirrord against the playground GKE cluster. Requires Playwright UI verification for catalog or frontend-affecting changes, not curl alone.
 ---
 
 # Mirrord Run Shop
 
-Use this for the local inner loop against https://playground.metalbear.dev/shop.
+Use this for the local inner loop against `https://playground.metalbear.dev/shop`.
 
-`curl` alone is not enough to mark shop or inventory work verified. Playwright catches UI failures (broken product images, empty `image_urls[0]`, layout regressions) that API JSON checks miss.
+`curl` alone is not enough to mark shop or inventory work verified. Playwright
+catches UI failures (broken product images, empty `image_urls[0]`, layout
+regressions) that API JSON checks miss.
 
-For the full PR → preview-build → agent iteration loop, use `mirrord-agent-shop` instead.
+For full agent-owned implementation and validation, use `mirrord-agent-shop`.
+That skill also uses local mirrord; it must not use the preview workflow.
 
 ## Service Map
 
@@ -22,6 +25,8 @@ For the full PR → preview-build → agent iteration loop, use `mirrord-agent-s
 
 ## Checks Before Start
 
+Run these before starting the service:
+
 ```bash
 mirrord --version
 kubectl config current-context
@@ -29,7 +34,8 @@ kubectl -n shop get deploy <deployment>
 ls apps/shop/<service>/mirrord.json
 ```
 
-The kube context must be `gke_playground-383912_us-central1-c_playground-cluster-1`.
+The kube context must be
+`gke_playground-383912_us-central1-c_playground-cluster-1`.
 
 Set a stable session for the whole run:
 
@@ -37,9 +43,14 @@ Set a stable session for the whole run:
 export MIRRORD_SESSION="${MIRRORD_SESSION:-${USER:-cursor-shop}}"
 ```
 
+Use a session value without slashes. The service `mirrord.json` files use the
+`USER` environment variable as the mirrord key, so pass `USER="$MIRRORD_SESSION"`
+when starting the process.
+
 ## Run Under mirrord
 
-Use absolute paths; `mirrord exec` must be the leading command:
+Use absolute paths; `mirrord exec` must be the command that starts the local app
+process:
 
 ```bash
 mkdir -p /tmp/mirrord-run
@@ -48,47 +59,81 @@ USER="$MIRRORD_SESSION" \
   npm --prefix /workspace/playground/apps/shop/<service> run dev
 ```
 
-Route only your traffic with:
+Do not widen `http_filter` in `mirrord.json` to make a test pass.
+
+## Reliable tmux Pattern
+
+Use tmux for long-running mirrord services. In this Cursor Cloud base container,
+`/exec-daemon/tmux.portal.conf` may be absent; when it is absent, use
+`tmux -f /dev/null`. Starting the mirrord command directly as the tmux session's
+initial command is the most reliable first attempt.
+
+```bash
+SESSION_NAME="<service>-mirrord"
+TMUX_CONFIG="/exec-daemon/tmux.portal.conf"
+if [ ! -f "$TMUX_CONFIG" ]; then TMUX_CONFIG="/dev/null"; fi
+
+tmux -f "$TMUX_CONFIG" kill-session -t "$SESSION_NAME" 2>/dev/null || true
+tmux -f "$TMUX_CONFIG" new-session -d -s "$SESSION_NAME" -c /workspace/playground \
+  "export MIRRORD_SESSION='$MIRRORD_SESSION'; \
+   export USER=\"\$MIRRORD_SESSION\"; \
+   mirrord exec -f /workspace/playground/apps/shop/<service>/mirrord.json -- \
+   npm --prefix /workspace/playground/apps/shop/<service> run dev"
+tmux -f "$TMUX_CONFIG" capture-pane -pt "$SESSION_NAME:0.0" -S -200
+```
+
+If you need follow-up input, use the same `TMUX_CONFIG` for `send-keys`:
+
+```bash
+tmux -f "$TMUX_CONFIG" send-keys -t "$SESSION_NAME:0.0" -l '<command>'
+tmux -f "$TMUX_CONFIG" send-keys -t "$SESSION_NAME:0.0" C-m
+```
+
+## Verify Traffic Is Stolen
+
+Route only your filtered traffic with:
 
 ```text
 baggage: mirrord-session=${MIRRORD_SESSION}
 ```
 
-Do not widen `http_filter` in `mirrord.json` to make a test pass.
-
-## Verify Traffic Is Stolen (curl)
-
-Confirm filtered traffic hits the local process and unfiltered traffic does not (see `.cursor/rules/00-mirrord-inventory-service.mdc` for inventory).
+Confirm filtered public traffic reaches the local process:
 
 ```bash
-curl -sS -H "baggage: mirrord-session=${MIRRORD_SESSION}" \
-  https://playground.metalbear.dev/shop/api/products | jq '.[0:3] | .[] | {id, name, image_urls}'
+curl -sS \
+  -H "baggage: mirrord-session=${MIRRORD_SESSION}" \
+  https://playground.metalbear.dev/shop/api/products | jq '.[0:5] | .[] | {id, name, image_urls}'
+```
 
+Send one matching unfiltered request while mirrord is running and confirm it does
+not appear in the local service logs:
+
+```bash
 curl -sS https://playground.metalbear.dev/shop/api/products | jq '.[0] | {id, name}'
 ```
 
-Check the local service log for the filtered request; confirm the unfiltered request does **not** appear locally.
+## Verify the Shop UI With Playwright
 
-## Verify the Shop UI (Playwright) — required
+Run Playwright after mirrord is up whenever the change affects products, images,
+catalog APIs, or anything the shop UI renders.
 
-Run Playwright after mirrord is up whenever the change affects products, images, catalog APIs, or anything the shop UI renders.
-
-**Never** mutate the shared playground Postgres (or any cluster DB) to “verify” or “fix” data. Validate through the public shop path with mirrord + baggage only. Repair logic belongs in service code on your branch, not in ad-hoc `kubectl exec` SQL.
+Never mutate the shared playground Postgres (or any cluster DB) to "verify" or
+"fix" data. Validate through the public shop path with mirrord + baggage, or
+through a local frontend wired to local/mirrord-backed services.
 
 ### Install once per session
 
 ```bash
-mkdir -p /tmp/mirrord-run-shop && cd /tmp/mirrord-run-shop
-[ -f package.json ] || npm init -y >/dev/null
-[ -d node_modules/playwright ] || npm install --save-dev playwright >/dev/null
-npx playwright install chromium --with-deps
-mkdir -p /tmp/screenshots
+mkdir -p /tmp/mirrord-run-shop /tmp/screenshots
+[ -d /tmp/mirrord-run-shop/node_modules/playwright ] || npm --prefix /tmp/mirrord-run-shop install playwright
+npx --prefix /tmp/mirrord-run-shop playwright install chromium
 rm -f /tmp/mirrord-run-shop/e2e.js /tmp/screenshots/mirrord-run-*
 ```
 
-### Write `/tmp/mirrord-run-shop/e2e.js`
+### Backend/catalog public-path baseline
 
-Adapt checks to the change. Keep this baseline for inventory / product-image work:
+Use the public shop URL and baggage header so the request goes through the same
+gateway and frontend API path a user uses:
 
 ```js
 const { chromium } = require("playwright");
@@ -96,75 +141,40 @@ const fs = require("fs");
 
 (async () => {
   const session = process.env.MIRRORD_SESSION;
-  if (!session) {
-    console.error("Set MIRRORD_SESSION");
-    process.exit(1);
-  }
-  const baggage = `mirrord-session=${session}`;
+  if (!session) throw new Error("Set MIRRORD_SESSION");
+
   const shopUrl = "https://playground.metalbear.dev/shop";
-  const shotsDir = "/tmp/screenshots";
-  const results = { session, checks: [], screenshots: [] };
+  const baggage = `mirrord-session=${session}`;
+  const results = { checks: [], screenshots: [] };
 
   const check = (name, ok, detail = "") => {
     results.checks.push({ name, ok, detail });
-    console.log(`${ok ? "PASS" : "FAIL"} ${name}${detail ? ` — ${detail}` : ""}`);
+    console.log(`${ok ? "PASS" : "FAIL"} ${name}${detail ? ` - ${detail}` : ""}`);
   };
 
   const browser = await chromium.launch();
-  const context = await browser.newContext({
-    extraHTTPHeaders: { baggage },
-  });
+  const context = await browser.newContext({ extraHTTPHeaders: { baggage } });
   const page = await context.newPage();
 
-  const assertImgLoaded = async (locator, label) => {
-    await locator.first().waitFor({ state: "visible", timeout: 20000 });
-    const info = await locator.first().evaluate((img) => ({
-      complete: img.complete,
-      naturalWidth: img.naturalWidth,
-      src: img.currentSrc || img.src,
-    }));
-    const ok = info.complete && info.naturalWidth > 0;
-    check(`${label} image loaded`, ok, JSON.stringify(info));
-    return ok;
-  };
-
   try {
-    // --- API: catch malformed image_urls (e.g. leading "") ---
     const productsRes = await page.request.get(`${shopUrl}/api/products`, {
       headers: { baggage },
     });
     const products = await productsRes.json();
-    check("GET /api/products", productsRes.ok(), `status ${productsRes.status()}`);
+    check("GET /api/products", productsRes.ok(), `status=${productsRes.status()}`);
 
     const badImageRows = (Array.isArray(products) ? products : []).filter((p) => {
       const urls = p.image_urls;
       if (!Array.isArray(urls) || urls.length === 0) return false;
-      const first = urls[0];
-      return typeof first !== "string" || first.trim() === "";
+      return typeof urls[0] !== "string" || urls[0].trim() === "";
     });
     check(
       "no product has empty image_urls[0]",
       badImageRows.length === 0,
-      badImageRows.length
-        ? `ids=${badImageRows.map((p) => p.id).join(",")} urls=${JSON.stringify(badImageRows[0].image_urls)}`
-        : `checked ${products.length} products`
+      badImageRows.length ? `ids=${badImageRows.map((p) => p.id).join(",")}` : `checked=${products.length}`,
     );
 
-    const p2Res = await page.request.get(`${shopUrl}/api/products/2`, { headers: { baggage } });
-    const p2 = await p2Res.json();
-    check("GET /api/products/2", p2Res.ok(), `status ${p2Res.status()}`);
-    const p2first = Array.isArray(p2.image_urls) ? p2.image_urls[0] : null;
-    check(
-      "product 2 image_urls[0] usable",
-      typeof p2first === "string" && p2first.trim().length > 0,
-      `image_urls=${JSON.stringify(p2.image_urls)} image_url=${p2.image_url}`
-    );
-
-    // --- UI: product list + detail images actually render ---
-    await page.goto(`${shopUrl}/products`, {
-      waitUntil: "domcontentloaded",
-      timeout: 30000,
-    });
+    await page.goto(`${shopUrl}/products`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle", { timeout: 30000 }).catch(() => {});
 
     const noImageTiles = await page.getByText("No image", { exact: true }).count();
@@ -173,54 +183,50 @@ const fs = require("fs");
     const gridImgs = page.locator('a[href*="/products/"] img');
     const gridCount = await gridImgs.count();
     check("products grid shows images", gridCount > 0, `img count=${gridCount}`);
-    if (gridCount > 0) await assertImgLoaded(gridImgs, "products grid");
-
-    const p2Path = `${shopUrl}/products/2`;
-    await page.screenshot({ path: `${shotsDir}/mirrord-run-products.png`, fullPage: true });
-    results.screenshots.push(`${shotsDir}/mirrord-run-products.png`);
-
-    await page.goto(p2Path, { waitUntil: "domcontentloaded", timeout: 30000 });
-    await page.waitForLoadState("networkidle", { timeout: 30000 }).catch(() => {});
-
-    const detailNoImage = await page.getByText("No image", { exact: true }).count();
-    check("product 2 detail has no 'No image' placeholder", detailNoImage === 0, `count=${detailNoImage}`);
-
-    const heroImg = page.locator(".aspect-square img");
-    if ((await heroImg.count()) > 0) {
-      await assertImgLoaded(heroImg, "product 2 detail hero");
-    } else {
-      check("product 2 detail hero image present", false, "no .aspect-square img found");
+    if (gridCount > 0) {
+      const info = await gridImgs.first().evaluate((img) => ({
+        complete: img.complete,
+        naturalWidth: img.naturalWidth,
+        src: img.currentSrc || img.src,
+      }));
+      check("first grid image loaded", info.complete && info.naturalWidth > 0, JSON.stringify(info));
     }
 
-    await page.screenshot({ path: `${shotsDir}/mirrord-run-product-2.png`, fullPage: true });
-    results.screenshots.push(`${shotsDir}/mirrord-run-product-2.png`);
+    await page.screenshot({ path: "/tmp/screenshots/mirrord-run-products.png", fullPage: true });
+    results.screenshots.push("/tmp/screenshots/mirrord-run-products.png");
   } catch (err) {
     check("fatal", false, err.message || String(err));
-    try {
-      await page.screenshot({ path: `${shotsDir}/mirrord-run-fatal.png`, fullPage: true });
-      results.screenshots.push(`${shotsDir}/mirrord-run-fatal.png`);
-    } catch {}
   } finally {
     await browser.close();
     fs.writeFileSync("/tmp/screenshots/mirrord-run-results.json", JSON.stringify(results, null, 2));
-    const allOk = results.checks.every((c) => c.ok);
-    console.log(`\n${results.checks.filter((c) => c.ok).length}/${results.checks.length} checks passed`);
-    process.exit(allOk ? 0 : 1);
+    process.exit(results.checks.every((c) => c.ok) ? 0 : 1);
   }
 })();
+```
+
+### Frontend-local baseline
+
+For frontend-only validation, run the frontend locally and validate
+`http://127.0.0.1:3000/shop`. Point API env vars at local or mirrord-backed
+service URLs:
+
+```bash
+NEXT_BASE_PATH=/shop \
+NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=dxas4fpir \
+INVENTORY_SERVICE_URL=http://127.0.0.1:80 \
+npm --prefix /workspace/playground/apps/shop/metal-mart-frontend run dev
 ```
 
 ### Run Playwright
 
 ```bash
-cd /tmp/mirrord-run-shop
-MIRRORD_SESSION="${MIRRORD_SESSION}" node e2e.js
+MIRRORD_SESSION="${MIRRORD_SESSION}" node /tmp/mirrord-run-shop/e2e.js
 cat /tmp/screenshots/mirrord-run-results.json
 ```
 
-### Review screenshots
-
-Use the image-reading tool on every PNG under `/tmp/screenshots/mirrord-run-*.png`. A visual failure (broken image icon, wrong product photo, empty tile) counts as a failed verification even if a narrow assertion passed.
+Review every PNG under `/tmp/screenshots/mirrord-run-*.png`. A visual failure
+(broken image icon, wrong product photo, empty tile) counts as a failed
+verification even if a narrow assertion passed.
 
 ## Completion Criteria
 
@@ -228,20 +234,20 @@ Do not mark shop or inventory work verified until all of the following hold:
 
 - `npm --prefix apps/shop/<service> run lint` or `run build` passes for touched services
 - Filtered public requests reach the local mirrord process; unfiltered requests do not
-- Playwright exits 0 with the checks above (adapted if the change scope differs)
+- Playwright exits 0 with checks adapted to the change scope
 - Screenshots reviewed; product images visibly load on `/shop/products` and affected detail pages
 - No unauthorized writes to shared cluster databases
 
 ## Inventory-Specific
 
-For `inventory-service`, also follow `.cursor/rules/00-mirrord-inventory-service.mdc` and `.cursor/rules/01-no-staging-api-without-mirrord.mdc`.
+For `inventory-service`, also follow `.cursor/rules/00-mirrord-inventory-service.mdc`
+and `.cursor/rules/01-no-staging-api-without-mirrord.mdc`.
 
 ## Handoff Block
 
-```
+```text
 ✓ <service> running under mirrord (session: ${MIRRORD_SESSION})
-  Log: check terminal / tmux session
   Header: baggage: mirrord-session=${MIRRORD_SESSION}
   Playwright: /tmp/screenshots/mirrord-run-results.json
-  Screenshots: /tmp/screenshots/mirrord-run-products.png, mirrord-run-product-2.png
+  Screenshots: /tmp/screenshots/mirrord-run-products.png
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rework `mirrord-agent-shop` so validation uses local `mirrord exec` and Playwright instead of preview workflow dispatch.
- Require backend/inventory validation to keep the deployed staging frontend/gateway in the request path and use filtered public shop requests; local/mirrord frontend runs are only for frontend code changes.
- Expand `mirrord-run-shop` with the same local validation expectations, filtered/unfiltered traffic proof, generic Playwright checks, and screenshot review.
- Document a reliable tmux pattern for this base container using `tmux -f /dev/null` when `/exec-daemon/tmux.portal.conf` is absent.

## Testing
- `git diff --check -- .cursor/skills/mirrord-run-shop/SKILL.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cc56cdb-1389-4d5d-aeb1-298e492a582b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cc56cdb-1389-4d5d-aeb1-298e492a582b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

