### PR TITLE
Fix product 2 image response

### DIFF
--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -5,6 +5,68 @@ import { Pool } from "pg";
 const app = express();
 const port = parseInt(process.env.PORT || "80", 10);
 
+type ProductRow = {
+  id: number;
+  name: string;
+  description: string | null;
+  price_cents: number;
+  stock: number;
+  image_url: string | null;
+  image_urls: unknown;
+  is_new: boolean;
+};
+
+type ProductResponse = Omit<ProductRow, "image_urls"> & {
+  image_urls: string[];
+};
+
+const PRODUCT_IMAGE_REPAIRS: Record<number, { imageUrls: string[]; staleValues: Set<string> }> = {
+  2: {
+    imageUrls: [
+      "team_Work_makes_the_Dream_Work_-_front_w5qdnb",
+      "team_work_makes_the_dream_work_-_back_onanux",
+    ],
+    staleValues: new Set(["Metal Mart/samples/mirrord-hoodie-front"]),
+  },
+};
+
+function asNonEmptyStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function cleanLegacyImageUrl(value: string | null): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeProductImages(row: ProductRow): ProductResponse {
+  const imageUrls = asNonEmptyStrings(row.image_urls);
+  const legacyImageUrl = cleanLegacyImageUrl(row.image_url);
+  const repair = PRODUCT_IMAGE_REPAIRS[row.id];
+
+  if (
+    repair &&
+    (imageUrls.length === 0 || imageUrls.some((imageUrl) => repair.staleValues.has(imageUrl)))
+  ) {
+    return {
+      ...row,
+      image_url: repair.imageUrls[0],
+      image_urls: repair.imageUrls,
+    };
+  }
+
+  return {
+    ...row,
+    image_url: legacyImageUrl,
+    image_urls: imageUrls.length > 0 ? imageUrls : legacyImageUrl ? [legacyImageUrl] : [],
+  };
+}
+
 let dbUrl = process.env.DATABASE_URL || "postgresql://postgres:postgres@localhost:5432/inventory";
 // mirrord branch DB URLs may omit the database name — ensure we connect to "inventory"
 if (dbUrl && !/:\d+\/.+$/.test(dbUrl)) {
@@ -73,7 +135,7 @@ app.get("/products", async (_req, res) => {
   // Set a breakpoint here; trigger with: curl http://localhost:28080/products -H "X-PG-Tenant: dev" (while port-forward + mirrord are running)
   try {
     const { rows } = await pool.query("SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id");
-    res.json(rows);
+    res.json(rows.map((row: ProductRow) => normalizeProductImages(row)));
   } catch (err) {
     console.error("Error fetching products:", err);
     res.status(500).json({ error: "Internal server error" });
@@ -93,7 +155,7 @@ app.get("/products/:id", async (req, res) => {
     if (rows.length === 0) {
       return res.status(404).json({ error: "Product not found" });
     }
-    res.json(rows[0]);
+    res.json(normalizeProductImages(rows[0] as ProductRow));
   } catch (err) {
     console.error("Error fetching product:", err);
     res.status(500).json({ error: "Internal server error" });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Normalize inventory product image arrays before returning API responses.
- Repair product id 2's known stale image values to the valid Team Work T-shirt Cloudinary IDs without mutating the shared database.

## Verification
- `npm --prefix apps/shop/inventory-service run build`
- `npm --prefix apps/shop/inventory-service run lint`
- mirrord filtered API check: `/shop/api/products` and `/shop/api/products/2` with `baggage: mirrord-session=productimage` returned clean product 2 `image_urls`.
- unfiltered API check showed the original broken staging data and did not appear in local inventory logs.
- Playwright with the same baggage header passed product 2 API, products grid image, and detail page image checks.

## Screenshots

### Products grid
[Products grid showing product 2 image loaded](https://cursor.com/agents/bc-73ffebd8-bcbb-4b64-b60b-76bf6e46245c/artifacts?path=%2Ftmp%2Fscreenshots%2Fproduct-image-products.png)

### Product detail
[Product detail showing product 2 image loaded](https://cursor.com/agents/bc-73ffebd8-bcbb-4b64-b60b-76bf6e46245c/artifacts?path=%2Ftmp%2Fscreenshots%2Fproduct-image-detail.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73ffebd8-bcbb-4b64-b60b-76bf6e46245c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73ffebd8-bcbb-4b64-b60b-76bf6e46245c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

