### PR TITLE
Stage Playwright screenshots for PR upload

### DIFF
--- a/.claude/commands/mirrord-agent-shop.md
+++ b/.claude/commands/mirrord-agent-shop.md
@@ -249,6 +249,14 @@ cat /tmp/screenshots/iter<n>-results.json
 
 **4d. Self-review visually:** for every `iter<n>-*.png`, use the `Read` tool to view the image and compare against the visual criteria written in the Phase 2 plan. If the screenshot doesn't match — heading missing, layout broken, element not visible, unexpected empty state — record that as a failed check **even if the Playwright assertions passed**. Add the visual failure to the results summary.
 
+**4e. Stage screenshots for the PR** (after the final passing run):
+
+```bash
+.cursor/scripts/stage-playwright-screenshots.sh /tmp/screenshots/iter<n>-*.png
+```
+
+Update the PR body with a **Playwright verification** section using the printed `<img>` tags (paths under `/opt/cursor/artifacts/screenshots/`). Re-run staging and update the PR again after any validation-driven fix.
+
 ### Phase 5 — Agent-internal iteration (no developer involvement)
 
 If any functional check failed, any visual self-review flagged a problem, or the preview build failed:

--- a/.claude/commands/mirrord-run.md
+++ b/.claude/commands/mirrord-run.md
@@ -85,6 +85,7 @@ If the response shows the **old** behavior, the request didn't get stolen. Most 
 2. Write and run `e2e.js` with `extraHTTPHeaders: { baggage: 'mirrord-session=' + $USER }`.
 3. Assert API rows have no empty `image_urls[0]`, and that `/shop/products` and affected detail pages show loaded images (`naturalWidth > 0`, no `No image` tiles).
 4. Review screenshots in `/tmp/screenshots/mirrord-run-*.png`.
+5. If opening or updating a PR, run `.cursor/scripts/stage-playwright-screenshots.sh` and embed the printed `<img>` tags in the PR body under a **Playwright verification** section.
 
 **Never** run ad-hoc `kubectl exec` SQL against the shared playground database to fix or test data. Validate only through mirrord + public shop URLs.
 

--- a/.cursor/rules/00-mirrord-inventory-service.mdc
+++ b/.cursor/rules/00-mirrord-inventory-service.mdc
@@ -138,4 +138,5 @@ target, filter, and request path before changing product code.
 - An unfiltered request to the same public endpoint does not reach the local service.
 - The changed inventory behavior is verified through the public shop path and the local mirrord process.
 - Run the Playwright checks in `.cursor/skills/mirrord-run-shop/SKILL.md` (API `image_urls` sanity + product images load on `/shop/products` and affected detail pages). Review screenshots; do not mark verified on `curl` alone.
+- When opening or updating a PR, stage Playwright screenshots with `.cursor/scripts/stage-playwright-screenshots.sh` and embed them in the PR body via `<img src="/opt/cursor/artifacts/screenshots/...">` tags (see the skill's "Upload Screenshots to the PR" section).
 - Never mutate the shared playground database with ad-hoc SQL; validate only via mirrord + public shop traffic.

--- a/.cursor/scripts/stage-playwright-screenshots.sh
+++ b/.cursor/scripts/stage-playwright-screenshots.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copy Playwright screenshots from /tmp into /opt/cursor/artifacts/screenshots
+# so ManagePullRequest can upload them when creating or updating a PR.
+#
+# Usage:
+#   .cursor/scripts/stage-playwright-screenshots.sh [glob...]
+#
+# Examples:
+#   .cursor/scripts/stage-playwright-screenshots.sh
+#   .cursor/scripts/stage-playwright-screenshots.sh /tmp/screenshots/mirrord-run-*.png
+#   .cursor/scripts/stage-playwright-screenshots.sh /tmp/screenshots/iter1-*.png
+#
+# With no arguments, stages common mirrord Playwright outputs:
+#   /tmp/screenshots/mirrord-run-*.png
+#   /tmp/screenshots/iter*-*.png
+
+set -euo pipefail
+
+DEST="/opt/cursor/artifacts/screenshots"
+mkdir -p "$DEST"
+
+shopt -s nullglob
+
+if [ "$#" -gt 0 ]; then
+  patterns=("$@")
+else
+  patterns=(
+    /tmp/screenshots/mirrord-run-*.png
+    /tmp/screenshots/iter*-*.png
+  )
+fi
+
+staged=()
+for pattern in "${patterns[@]}"; do
+  for src in $pattern; do
+    [ -f "$src" ] || continue
+    base="$(basename "$src")"
+    dest="$DEST/$base"
+    cp -f "$src" "$dest"
+    staged+=("$dest")
+    echo "staged: $dest"
+  done
+done
+
+if [ "${#staged[@]}" -eq 0 ]; then
+  echo "No screenshots found to stage." >&2
+  exit 1
+fi
+
+# Print HTML img tags for PR bodies (ManagePullRequest uploads these paths).
+echo ""
+echo "PR body snippets:"
+for path in "${staged[@]}"; do
+  alt="$(basename "$path" .png | tr '_-' ' ')"
+  echo "<img alt=\"${alt}\" src=\"${path}\" />"
+done

--- a/.cursor/skills/mirrord-agent-shop/SKILL.md
+++ b/.cursor/skills/mirrord-agent-shop/SKILL.md
@@ -57,7 +57,7 @@ objects.
   the same commit as the UI change.
 - Commit and push the implementation before validation starts.
 - Open or update the PR before validation starts; update it again after any
-  validation-driven fixes.
+  validation-driven fixes, including Playwright screenshots (see Phase 6).
 
 Capture:
 
@@ -187,6 +187,28 @@ Run the script and save JSON results under `/tmp/screenshots/iter<n>-results.jso
 Review every screenshot with the available image-viewing tool. A visual mismatch
 counts as failed verification even if Playwright exits 0.
 
+### Stage screenshots for the PR
+
+After the final passing Playwright run, stage screenshots for PR upload:
+
+```bash
+.cursor/scripts/stage-playwright-screenshots.sh /tmp/screenshots/iter<n>-*.png
+```
+
+Update the PR body with a **Playwright verification** section that embeds the
+staged images using the printed `<img>` tags. Paths must be under
+`/opt/cursor/artifacts/screenshots/` so the PR tool uploads them:
+
+```html
+## Playwright verification
+
+<img alt="iter1 home" src="/opt/cursor/artifacts/screenshots/iter1-home.png" />
+<img alt="iter1 products" src="/opt/cursor/artifacts/screenshots/iter1-products.png" />
+```
+
+Include one `<img>` per visual check from the test plan. Do not hand off without
+uploading screenshots when Playwright was used.
+
 ## Phase 7: Internal Iteration
 
 If a functional check fails, screenshot review fails, or a local service fails to
@@ -197,7 +219,7 @@ start:
 3. Fix the code or fix the test.
 4. Commit and push the iteration fix.
 5. Restart the local mirrord service and rerun validation.
-6. Update the PR.
+6. Update the PR (re-stage and embed screenshots after the final passing run).
 
 Internal cap: 3 attempts. If still failing, report that directly and ask for
 developer input.

--- a/.cursor/skills/mirrord-run-shop/SKILL.md
+++ b/.cursor/skills/mirrord-run-shop/SKILL.md
@@ -234,6 +234,30 @@ cat /tmp/screenshots/mirrord-run-results.json
 Review every PNG under `/tmp/screenshots/mirrord-run-*.png`. A visual failure
 counts as a failed verification even if a narrow assertion passed.
 
+## Upload Screenshots to the PR
+
+When opening or updating a PR after Playwright verification, stage screenshots so
+the PR management tool can upload them:
+
+```bash
+.cursor/scripts/stage-playwright-screenshots.sh
+```
+
+This copies PNGs from `/tmp/screenshots/` into
+`/opt/cursor/artifacts/screenshots/` and prints `<img>` tags for the PR body.
+
+When creating or updating the PR, include a **Playwright verification** section
+with those tags. Example:
+
+```html
+## Playwright verification
+
+<img alt="mirrord run products" src="/opt/cursor/artifacts/screenshots/mirrord-run-products.png" />
+```
+
+Do not mark verification complete or leave the PR without screenshots when
+Playwright was part of the validation.
+
 ## Completion Criteria
 
 Do not mark shop or inventory work verified until all of the following hold:
@@ -242,6 +266,7 @@ Do not mark shop or inventory work verified until all of the following hold:
 - Filtered public requests reach the local mirrord process; unfiltered requests do not
 - Playwright exits 0 with checks adapted to the change scope
 - Screenshots reviewed; product images visibly load on `/shop/products` and affected detail pages
+- Playwright screenshots staged and embedded in the PR body when a PR is opened or updated
 - No unauthorized writes to shared cluster databases
 
 ## Inventory-Specific


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ensures cloud agents embed Playwright verification screenshots in PR bodies when opening or updating pull requests after mirrord shop validation.

## Changes

- **New script:** `.cursor/scripts/stage-playwright-screenshots.sh` copies PNGs from `/tmp/screenshots/` into `/opt/cursor/artifacts/screenshots/` and prints `<img>` tags for the PR management tool to upload.
- **Skills updated:** `mirrord-run-shop` and `mirrord-agent-shop` now require staging and embedding screenshots in the PR after Playwright passes.
- **Rules/commands updated:** `00-mirrord-inventory-service.mdc`, `mirrord-run`, and `mirrord-agent-shop` commands reference the same workflow.

## Workflow

After Playwright verification:

```bash
.cursor/scripts/stage-playwright-screenshots.sh
```

Then include the printed tags in the PR body:

```html
## Playwright verification

<img alt="..." src="/opt/cursor/artifacts/screenshots/..." />
```

## Playwright verification

[mirrord run test](https://cursor.com/agents/bc-0ebaa87f-2405-4183-8dc9-0ed308ff8a85/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmirrord-run-test.png)

(Example staged image demonstrating the upload path.)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ebaa87f-2405-4183-8dc9-0ed308ff8a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ebaa87f-2405-4183-8dc9-0ed308ff8a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

