### PR TITLE
Enable PostgreSQL db branching for inventory-service (local + preview)

### DIFF
--- a/.github/preview-services.json
+++ b/.github/preview-services.json
@@ -32,7 +32,7 @@
       "deployment": "inventory-service",
       "namespace": "shop",
       "build_args": "",
-      "extra_config": "{\"feature\":{\"preview\":{\"creation_timeout_secs\":600}}}"
+      "extra_config": "{\"feature\":{\"preview\":{\"creation_timeout_secs\":600},\"db_branches\":[{\"id\":\"{{ key }}\",\"type\":\"pg\",\"ttl_secs\":30,\"version\":\"16.0\",\"connection\":{\"url\":\"DATABASE_URL\"},\"copy\":{\"mode\":\"schema\"}}]}}"
     },
     {
       "name": "payment-service",

--- a/.github/preview-services.json
+++ b/.github/preview-services.json
@@ -32,7 +32,7 @@
       "deployment": "inventory-service",
       "namespace": "shop",
       "build_args": "",
-      "extra_config": "{\"feature\":{\"preview\":{\"creation_timeout_secs\":600},\"db_branches\":[{\"id\":\"{{ key }}\",\"type\":\"pg\",\"ttl_secs\":30,\"version\":\"16.0\",\"connection\":{\"url\":\"DATABASE_URL\"},\"copy\":{\"mode\":\"schema\"}}]}}"
+      "extra_config": "{\"feature\":{\"preview\":{\"creation_timeout_secs\":600},\"db_branches\":[{\"id\":\"{{ key }}\",\"type\":\"pg\",\"ttl_secs\":30,\"version\":\"16.0\",\"connection\":{\"url\":\"DATABASE_URL\"},\"copy\":{\"mode\":\"all\"}}]}}"
     },
     {
       "name": "payment-service",

--- a/apps/shop/inventory-service/mirrord.json
+++ b/apps/shop/inventory-service/mirrord.json
@@ -13,6 +13,20 @@
         }
       },
       "outgoing": true
-    }
+    },
+    "db_branches": [
+      {
+        "id": "{{key}}01-branch-db",
+        "type": "pg",
+        "ttl_secs": 30,
+        "version": "16.0",
+        "connection": {
+          "url": "DATABASE_URL"
+        },
+        "copy": {
+          "mode": "schema"
+        }
+      }
+    ]
   }
 }

--- a/apps/shop/inventory-service/mirrord.json
+++ b/apps/shop/inventory-service/mirrord.json
@@ -24,7 +24,7 @@
           "url": "DATABASE_URL"
         },
         "copy": {
-          "mode": "schema"
+          "mode": "all"
         }
       }
     ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables PostgreSQL db branching for inventory-service with **full data copy** (`copy.mode: "all"`).

### 1. Local mirrord (`apps/shop/inventory-service/mirrord.json`)

Adds `db_branches` so `mirrord exec` sessions get an isolated PostgreSQL branch via `DATABASE_URL`, copying schema **and data** from the shared database.

### 2. Preview environments (`.github/preview-services.json`)

Preview CI does **not** read `mirrord.json`. The shop preview workflow passes each service's `extra_config` from `preview-services.json` to `metalbear-co/mirrord-preview`. Inventory-service now includes `db_branches` with `copy.mode: "all"`, matching the full-data behavior for preview pods.

| Context | Config source | Copy mode |
|---|---|---|
| Local `mirrord exec` | `apps/shop/inventory-service/mirrord.json` | `all` |
| PR preview pods | `.github/preview-services.json` → `extra_config` | `all` |

## Testing

- `npm --prefix apps/shop/inventory-service run build` — passes
- JSON validated for both config files

Live mirrord/preview verification against the playground cluster was not run in this cloud agent environment (no GKE/kubeconfig).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06a6ae2c-0682-4f19-a830-53e7906e3630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06a6ae2c-0682-4f19-a830-53e7906e3630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

