### PR TITLE
Fix product 2 image not loading in shop UI

### DIFF
--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -5,6 +5,49 @@ import { Pool } from "pg";
 const app = express();
 const port = parseInt(process.env.PORT || "80", 10);
 
+type ProductRow = {
+  id: number;
+  name: string;
+  description: string | null;
+  price_cents: number;
+  stock: number;
+  image_url: string | null;
+  image_urls: unknown;
+  is_new: boolean;
+};
+
+const deprecatedImageReplacements: Record<string, string[]> = {
+  "Metal Mart/samples/mirrord-hoodie-front": [
+    "team_Work_makes_the_Dream_Work_-_front_w5qdnb",
+    "team_work_makes_the_dream_work_-_back_onanux",
+  ],
+};
+
+function normalizeImageValue(value: unknown): string[] {
+  if (typeof value !== "string") return [];
+
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+
+  return deprecatedImageReplacements[trimmed] ?? [trimmed];
+}
+
+function normalizeImageUrls(imageUrls: unknown, imageUrl: unknown): string[] {
+  const urls = Array.isArray(imageUrls) ? imageUrls.flatMap(normalizeImageValue) : [];
+  if (urls.length > 0) return urls;
+
+  return normalizeImageValue(imageUrl);
+}
+
+function normalizeProductRow(row: ProductRow) {
+  const image_urls = normalizeImageUrls(row.image_urls, row.image_url);
+  return {
+    ...row,
+    image_url: image_urls[0] ?? null,
+    image_urls,
+  };
+}
+
 let dbUrl = process.env.DATABASE_URL || "postgresql://postgres:postgres@localhost:5432/inventory";
 // mirrord branch DB URLs may omit the database name — ensure we connect to "inventory"
 if (dbUrl && !/:\d+\/.+$/.test(dbUrl)) {
@@ -72,8 +115,8 @@ app.get("/health", (_req, res) => {
 app.get("/products", async (_req, res) => {
   // Set a breakpoint here; trigger with: curl http://localhost:28080/products -H "X-PG-Tenant: dev" (while port-forward + mirrord are running)
   try {
-    const { rows } = await pool.query("SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id");
-    res.json(rows);
+    const { rows } = await pool.query<ProductRow>("SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id");
+    res.json(rows.map(normalizeProductRow));
   } catch (err) {
     console.error("Error fetching products:", err);
     res.status(500).json({ error: "Internal server error" });
@@ -86,14 +129,14 @@ app.get("/products/:id", async (req, res) => {
     return res.status(400).json({ error: "Invalid product ID" });
   }
   try {
-    const { rows } = await pool.query(
+    const { rows } = await pool.query<ProductRow>(
       "SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products WHERE id = $1",
       [id]
     );
     if (rows.length === 0) {
       return res.status(404).json({ error: "Product not found" });
     }
-    res.json(rows[0]);
+    res.json(normalizeProductRow(rows[0]));
   } catch (err) {
     console.error("Error fetching product:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/apps/shop/metal-mart-frontend/src/lib/product.ts
+++ b/apps/shop/metal-mart-frontend/src/lib/product.ts
@@ -10,17 +10,23 @@ export type Product = {
   is_new?: boolean;
 };
 
+function normalizeImageUrl(url: string | null | undefined): string | null {
+  const trimmed = url?.trim();
+  return trimmed ? trimmed : null;
+}
+
 /** Primary image for thumbnails (first in array, or legacy image_url). */
 export function getPrimaryImageUrl(product: Product): string | null {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls[0];
-  return product.image_url ?? null;
+  return getImageUrls(product)[0] ?? null;
 }
 
 /** All image URLs for product (front, back, etc.). */
 export function getImageUrls(product: Product): string[] {
-  const urls = product.image_urls;
+  const urls = product.image_urls
+    ?.map((url) => normalizeImageUrl(url))
+    .filter((url): url is string => url !== null);
   if (urls && urls.length > 0) return urls;
-  const single = product.image_url;
+
+  const single = normalizeImageUrl(product.image_url);
   return single ? [single] : [];
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Product 2 (Team Work Makes The Dream Work T-Shirt) failed to show images because the shared inventory DB stores malformed `image_urls` (`[""]` plus a deprecated Cloudinary path `Metal Mart/samples/mirrord-hoodie-front`).

This PR normalizes catalog image data at the inventory API layer and adds a defensive empty-string filter in the frontend product helpers.

## Changes

- **inventory-service**: Add `normalizeProductRow` to strip empty `image_urls` entries and map deprecated Cloudinary paths to current public IDs (front + back for product 2).
- **metal-mart-frontend**: Filter blank strings in `getImageUrls` / `getPrimaryImageUrl` so the UI never tries to render an empty `src`.

## Verification (mirrord + Playwright)

Session: `cursor-fix-product-2-image-ad96`

**Filtered API (`baggage: mirrord-session=...`):**
```json
{
  "id": 2,
  "image_url": "team_Work_makes_the_Dream_Work_-_front_w5qdnb",
  "image_urls": [
    "team_Work_makes_the_Dream_Work_-_front_w5qdnb",
    "team_work_makes_the_dream_work_-_back_onanux"
  ]
}
```

**Unfiltered API** (cluster default, does not hit local process): still returns the bad DB row — confirms traffic stealing works and the fix is in local code.

**Playwright:** 9/9 checks passed — no empty `image_urls[0]`, product 2 detail hero loads (`naturalWidth: 640`), products grid has no "No image" tiles.

### Screenshots

Products grid — all tiles show images, no "No image" placeholders:

[Products grid after fix](https://cursor.com/agents/bc-5325c21c-51be-4e1f-a73e-fc9ba922ad96/artifacts?path=%2Ftmp%2Fscreenshots%2Fmirrord-run-products.png)

Product 2 detail — front hero image and back thumbnail load correctly:

[Product 2 detail after fix](https://cursor.com/agents/bc-5325c21c-51be-4e1f-a73e-fc9ba922ad96/artifacts?path=%2Ftmp%2Fscreenshots%2Fmirrord-run-product-2.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5325c21c-51be-4e1f-a73e-fc9ba922ad96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5325c21c-51be-4e1f-a73e-fc9ba922ad96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

