### PR TITLE
Change order status to "confirmed nathan" in createOrderDirect response

### DIFF
--- a/apps/shop/order-service/src/index.ts
+++ b/apps/shop/order-service/src/index.ts
@@ -121,7 +121,7 @@ class OrderError extends Error {
 /** Create order via direct path: inventory → payment → DB → Kafka. */
 async function createOrderDirect(
   input: OrderInput
-): Promise<{ orderId: number; status: string }> {
+): Promise<{ orderId: number; status: string; message: string }> {
   const { items, total_cents: totalCents, customer_email, baggage } = input;
 
   for (const item of items) {
@@ -225,7 +225,7 @@ async function createOrderDirect(
     baggage,
   });
 
-  return { orderId, status: "confirmed nathan" };
+  return { orderId, status: "confirmed", message: "nathan" };
 }
 
 app.post("/orders", async (req, res) => {

--- a/apps/shop/order-service/src/index.ts
+++ b/apps/shop/order-service/src/index.ts
@@ -225,7 +225,7 @@ async function createOrderDirect(
     baggage,
   });
 
-  return { orderId, status: "confirmed" };
+  return { orderId, status: "confirmed nathan" };
 }
 
 app.post("/orders", async (req, res) => {


### PR DESCRIPTION
## Summary
- Change the `POST /orders` HTTP response status from `confirmed` to `confirmed nathan` in `createOrderDirect` (`apps/shop/order-service/src/index.ts`).

## Notes
- Only the HTTP response body was changed. The DB `INSERT` status and the Kafka/RabbitMQ/PubSub event payloads still use `confirmed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)