### PR TITLE
Change order-service createOrderDirect response status to "confirmed mykolas"

### DIFF
--- a/apps/shop/order-service/src/index.ts
+++ b/apps/shop/order-service/src/index.ts
@@ -121,7 +121,7 @@ class OrderError extends Error {
 /** Create order via direct path: inventory → payment → DB → Kafka. */
 async function createOrderDirect(
   input: OrderInput
-): Promise<{ orderId: number; status: string }> {
+): Promise<{ orderId: number; status: string; message: string }> {
   const { items, total_cents: totalCents, customer_email, baggage } = input;
 
   for (const item of items) {
@@ -225,7 +225,7 @@ async function createOrderDirect(
     baggage,
   });
 
-  return { orderId, status: "confirmed mykolas" };
+  return { orderId, status: "confirmed", message: "mykolas" };
 }
 
 app.post("/orders", async (req, res) => {

--- a/apps/shop/order-service/src/index.ts
+++ b/apps/shop/order-service/src/index.ts
@@ -225,7 +225,7 @@ async function createOrderDirect(
     baggage,
   });
 
-  return { orderId, status: "confirmed" };
+  return { orderId, status: "confirmed mykolas" };
 }
 
 app.post("/orders", async (req, res) => {


### PR DESCRIPTION
## Summary
- Change the `POST /orders` HTTP response status returned by `createOrderDirect` from `"confirmed"` to `"confirmed mykolas"`.

Note: only the returned HTTP response value is changed. The DB insert, Kafka, RabbitMQ, and Pub/Sub events still use `"confirmed"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)