### PR TITLE
Fix product 2 image not loading in shop UI

### DIFF
--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -51,6 +51,18 @@ async function initDb() {
       UPDATE products SET image_urls = jsonb_build_array(image_url)
       WHERE (image_urls IS NULL OR image_urls = '[]'::jsonb) AND image_url IS NOT NULL
     `);
+    // Product 2 was seeded with a blank first image_urls entry and a stale sample ID.
+    await client.query(`
+      UPDATE products
+      SET image_urls = '["team_Work_makes_the_Dream_Work_-_front_w5qdnb","team_work_makes_the_dream_work_-_back_onanux"]'::jsonb,
+          image_url = NULL
+      WHERE id = 2
+        AND (
+          image_urls::text LIKE '%""%'
+          OR image_url = 'Metal Mart/samples/mirrord-hoodie-front'
+          OR image_urls::text LIKE '%mirrord-hoodie-front%'
+        )
+    `);
   } finally {
     client.release();
   }

--- a/apps/shop/metal-mart-frontend/src/lib/product.ts
+++ b/apps/shop/metal-mart-frontend/src/lib/product.ts
@@ -10,17 +10,23 @@ export type Product = {
   is_new?: boolean;
 };
 
+function nonEmptyImageUrls(urls: string[] | null | undefined): string[] {
+  if (!urls) return [];
+  return urls.filter((url) => typeof url === "string" && url.trim().length > 0);
+}
+
 /** Primary image for thumbnails (first in array, or legacy image_url). */
 export function getPrimaryImageUrl(product: Product): string | null {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls[0];
-  return product.image_url ?? null;
+  const urls = nonEmptyImageUrls(product.image_urls);
+  if (urls.length > 0) return urls[0];
+  const legacy = product.image_url?.trim();
+  return legacy || null;
 }
 
 /** All image URLs for product (front, back, etc.). */
 export function getImageUrls(product: Product): string[] {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls;
-  const single = product.image_url;
+  const urls = nonEmptyImageUrls(product.image_urls);
+  if (urls.length > 0) return urls;
+  const single = product.image_url?.trim();
   return single ? [single] : [];
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Product 2 ("Team Work Makes The Dream Work T-Shirt") showed a "No image" placeholder in the shop UI.

The inventory row had a blank first `image_urls` entry and a stale Cloudinary sample ID (`Metal Mart/samples/mirrord-hoodie-front`). The frontend treated the empty string as the primary image, which failed to render.

## Changes

- **inventory-service**: On startup, repair product 2 when it still has the bad `image_urls` / `image_url` values, restoring the correct front/back Cloudinary public IDs.
- **metal-mart-frontend**: Filter blank strings out of `image_urls` before picking a primary image (defensive fallback).

## Verification

Verified with mirrord (`MIRRORD_SESSION=cursor-fix-product-2-image-6444`) and filtered traffic through `https://playground.metalbear.dev/shop`.

- `GET /api/products/2` now returns valid `image_urls`
- No "No image" tiles on `/shop/products`
- Product 2 detail page loads the front t-shirt image (`naturalWidth > 0`)

## Playwright verification

[mirrord run products](https://cursor.com/agents/bc-9600d1ae-14a7-40ea-94fd-15a4ed176444/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmirrord-run-products.png)
[mirrord run product 2](https://cursor.com/agents/bc-9600d1ae-14a7-40ea-94fd-15a4ed176444/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmirrord-run-product-2.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9600d1ae-14a7-40ea-94fd-15a4ed176444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9600d1ae-14a7-40ea-94fd-15a4ed176444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

