### PR TITLE
Fix product 2 image not loading in shop UI

### DIFF
--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -13,6 +13,30 @@ if (dbUrl && !/:\d+\/.+$/.test(dbUrl)) {
 
 const pool = new Pool({ connectionString: dbUrl });
 
+type ProductRow = {
+  id: number;
+  name: string;
+  description: string | null;
+  price_cents: number;
+  stock: number;
+  image_url: string | null;
+  image_urls: string[] | null;
+  is_new: boolean;
+};
+
+function normalizeProductRow(row: ProductRow): ProductRow {
+  const urls = Array.isArray(row.image_urls)
+    ? row.image_urls.filter((url) => typeof url === "string" && url.trim() !== "")
+    : [];
+  const imageUrl =
+    typeof row.image_url === "string" && row.image_url.trim() !== "" ? row.image_url : null;
+  return {
+    ...row,
+    image_url: urls.length > 0 ? null : imageUrl,
+    image_urls: urls.length > 0 ? urls : imageUrl ? [imageUrl] : [],
+  };
+}
+
 async function initDb() {
   const client = await pool.connect();
   try {
@@ -51,6 +75,17 @@ async function initDb() {
       UPDATE products SET image_urls = jsonb_build_array(image_url)
       WHERE (image_urls IS NULL OR image_urls = '[]'::jsonb) AND image_url IS NOT NULL
     `);
+    // Repair product 2 when image_urls has a leading empty entry or stale sample placeholder
+    await client.query(`
+      UPDATE products SET
+        image_url = NULL,
+        image_urls = '["team_Work_makes_the_Dream_Work_-_front_w5qdnb","team_work_makes_the_dream_work_-_back_onanux"]'::jsonb
+      WHERE id = 2 AND (
+        image_urls->>0 = ''
+        OR image_url = 'Metal Mart/samples/mirrord-hoodie-front'
+        OR image_urls @> '["Metal Mart/samples/mirrord-hoodie-front"]'::jsonb
+      )
+    `);
   } finally {
     client.release();
   }
@@ -72,8 +107,10 @@ app.get("/health", (_req, res) => {
 app.get("/products", async (_req, res) => {
   // Set a breakpoint here; trigger with: curl http://localhost:28080/products -H "X-PG-Tenant: dev" (while port-forward + mirrord are running)
   try {
-    const { rows } = await pool.query("SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id");
-    res.json(rows);
+    const { rows } = await pool.query<ProductRow>(
+      "SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id"
+    );
+    res.json(rows.map(normalizeProductRow));
   } catch (err) {
     console.error("Error fetching products:", err);
     res.status(500).json({ error: "Internal server error" });
@@ -86,14 +123,14 @@ app.get("/products/:id", async (req, res) => {
     return res.status(400).json({ error: "Invalid product ID" });
   }
   try {
-    const { rows } = await pool.query(
+    const { rows } = await pool.query<ProductRow>(
       "SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products WHERE id = $1",
       [id]
     );
     if (rows.length === 0) {
       return res.status(404).json({ error: "Product not found" });
     }
-    res.json(rows[0]);
+    res.json(normalizeProductRow(rows[0]));
   } catch (err) {
     console.error("Error fetching product:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/apps/shop/metal-mart-frontend/src/lib/product.ts
+++ b/apps/shop/metal-mart-frontend/src/lib/product.ts
@@ -10,17 +10,23 @@ export type Product = {
   is_new?: boolean;
 };
 
+function nonEmptyImageUrls(urls: string[] | null | undefined): string[] {
+  if (!urls) return [];
+  return urls.filter((url) => typeof url === "string" && url.trim() !== "");
+}
+
 /** Primary image for thumbnails (first in array, or legacy image_url). */
 export function getPrimaryImageUrl(product: Product): string | null {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls[0];
-  return product.image_url ?? null;
+  const urls = nonEmptyImageUrls(product.image_urls);
+  if (urls.length > 0) return urls[0];
+  const single = product.image_url?.trim();
+  return single ? single : null;
 }
 
 /** All image URLs for product (front, back, etc.). */
 export function getImageUrls(product: Product): string[] {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls;
-  const single = product.image_url;
+  const urls = nonEmptyImageUrls(product.image_urls);
+  if (urls.length > 0) return urls;
+  const single = product.image_url?.trim();
   return single ? [single] : [];
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Product 2 ("Team Work Makes The Dream Work T-Shirt") failed to render an image because its `image_urls` array started with an empty string and fell back to a non-existent Cloudinary placeholder (`Metal Mart/samples/mirrord-hoodie-front`).

This change repairs product 2's image data at inventory-service startup and normalizes empty image URL entries in API responses and frontend helpers.

## Changes

- **inventory-service**: On startup, repair product 2 when it has the known bad `image_urls` / `image_url` values. Add `normalizeProductRow()` to strip empty strings from `image_urls` before returning products.
- **metal-mart-frontend**: Filter empty strings in `getPrimaryImageUrl()` / `getImageUrls()` so a blank first entry cannot block image rendering.

## Verification

- mirrord session: `fix-product-2-image-41f1`
- Header: `baggage: mirrord-session=fix-product-2-image-41f1`
- Filtered `GET https://playground.metalbear.dev/shop/api/products/2` returns valid front/back Cloudinary IDs
- Unfiltered request still hits cluster (not local process)
- Playwright: 8/8 checks passed

## Playwright verification

[iter1 products](https://cursor.com/agents/bc-6b83a5c8-0030-4fb6-8548-65d7f3a441f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fiter1-products.png)
[iter1 product 2 detail](https://cursor.com/agents/bc-6b83a5c8-0030-4fb6-8548-65d7f3a441f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fiter1-product-2-detail.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b83a5c8-0030-4fb6-8548-65d7f3a441f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b83a5c8-0030-4fb6-8548-65d7f3a441f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

