### PR TITLE
docs: require stopping mirrord when finishing shop work

### DIFF
--- a/.claude/commands/mirrord-run.md
+++ b/.claude/commands/mirrord-run.md
@@ -89,12 +89,12 @@ If the response shows the **old** behavior, the request didn't get stolen. Most 
 
 **Never** run ad-hoc `kubectl exec` SQL against the shared playground database to fix or test data. Validate only through mirrord + public shop URLs.
 
-## Phase 6 — Hand off to the developer
+## Phase 6 — Stop mirrord and hand off
 
-Print exactly this block, with values filled in:
+Stop mirrord first (see **Stop / cleanup** below), then print exactly this block with values filled in:
 
 ```
-✓ <service> is running locally under mirrord against staging.
+✓ <service> verified locally under mirrord against staging; mirrord stopped.
 
 Local log:   /tmp/mirrord-run/<service>.log
 Routing:     baggage: mirrord-session=<USER>
@@ -104,17 +104,23 @@ Playwright:  /tmp/screenshots/mirrord-run-results.json (see mirrord-run-shop ski
 To see it in the browser, install the mirrord Browser Extension and set
 the same baggage header — only your requests will hit the local process.
 
-Tell me when to stop it, or just give feedback and I'll iterate.
+If you need another validation pass, restart mirrord for that pass and stop it again when done.
 ```
 
 ## Stop / cleanup
 
-When the developer says they're done, or asks you to stop:
+Stop mirrord when verification is finished or when the developer asks you to stop. Do **not** leave
+mirrord running after handoff — it keeps stealing filtered traffic on the shared playground cluster.
 
-1. `TaskStop` the background Bash task.
-2. Optional: `rm /tmp/mirrord-run/<service>.log`.
+When finishing work:
 
-Do **not** auto-stop on your own — leave it running across follow-up edits unless the developer signals done. `tsx watch` and `next dev` will pick up source edits automatically without restarting mirrord.
+1. `TaskStop` the background Bash task, or send `Ctrl+C` to the foreground `mirrord exec` process.
+2. If you used tmux, kill the session: `tmux kill-session -t <service>-mirrord` (use the same `-f` config as start).
+3. Confirm cleanup: `pgrep -af "mirrord exec.*apps/shop/<service>" || echo "stopped"`.
+4. Optional: `rm /tmp/mirrord-run/<service>.log`.
+
+During an active iteration loop, `tsx watch` and `next dev` pick up source edits without restarting
+mirrord — but stop mirrord before marking the task complete or handing off.
 
 ## Guardrails
 

--- a/.cursor/rules/00-mirrord-inventory-service.mdc
+++ b/.cursor/rules/00-mirrord-inventory-service.mdc
@@ -140,3 +140,17 @@ target, filter, and request path before changing product code.
 - Run the Playwright checks in `.cursor/skills/mirrord-run-shop/SKILL.md` (API `image_urls` sanity + product images load on `/shop/products` and affected detail pages). Review screenshots; do not mark verified on `curl` alone.
 - When opening or updating a PR, stage Playwright screenshots with `.cursor/scripts/stage-playwright-screenshots.sh` and embed them in the PR body via `<img src="/opt/cursor/artifacts/screenshots/...">` tags (see the skill's "Upload Screenshots to the PR" section).
 - Never mutate the shared playground database with ad-hoc SQL; validate only via mirrord + public shop traffic.
+- Stop inventory-service mirrord after verification (see **Stop mirrord** in `.cursor/skills/mirrord-run-shop/SKILL.md`). Do not mark the task complete or hand off while mirrord is still running.
+
+## Stop mirrord
+
+After Playwright and curl checks pass, kill the local mirrord session before reporting done:
+
+```bash
+TMUX_CONFIG="/exec-daemon/tmux.portal.conf"
+if [ ! -f "$TMUX_CONFIG" ]; then TMUX_CONFIG="/dev/null"; fi
+tmux -f "$TMUX_CONFIG" kill-session -t "inventory-service-mirrord" 2>/dev/null || true
+pgrep -af "mirrord exec.*inventory-service" || echo "no inventory mirrord exec processes"
+```
+
+If mirrord was started in a foreground shell instead of tmux, send `Ctrl+C` to that process.

--- a/.cursor/rules/01-no-staging-api-without-mirrord.mdc
+++ b/.cursor/rules/01-no-staging-api-without-mirrord.mdc
@@ -68,3 +68,8 @@ If mirrord is not running, stop — use local-only testing or start mirrord firs
 ## Completion
 
 Do not mark shop backend work verified, and do not say responses were validated on staging, unless mirrord was running and filtered traffic showed the local behavior. See also `.cursor/skills/mirrord-run-shop/SKILL.md`.
+
+After verification, stop every mirrord session you started. Do not leave local mirrord running on
+handoff — filtered traffic would keep routing to your process on the shared playground cluster.
+Follow the **Stop mirrord** section in `.cursor/skills/mirrord-run-shop/SKILL.md` (or Phase 8 in
+`.cursor/skills/mirrord-agent-shop/SKILL.md` for agent-owned work).

--- a/.cursor/skills/mirrord-agent-shop/SKILL.md
+++ b/.cursor/skills/mirrord-agent-shop/SKILL.md
@@ -238,7 +238,35 @@ start:
 Internal cap: 3 attempts. If still failing, report that directly and ask for
 developer input.
 
-## Phase 8: Report Back
+## Phase 8: Stop mirrord
+
+After the final passing Playwright run (or when abandoning after the internal cap), stop every
+mirrord session you started. Do not hand off or mark work complete while mirrord is still running.
+
+### tmux sessions
+
+```bash
+TMUX_CONFIG="/exec-daemon/tmux.portal.conf"
+if [ ! -f "$TMUX_CONFIG" ]; then TMUX_CONFIG="/dev/null"; fi
+tmux -f "$TMUX_CONFIG" kill-session -t "<service>-mirrord" 2>/dev/null || true
+```
+
+Kill each `<service>-mirrord` session for every touched service.
+
+### Foreground or background shell
+
+Send `Ctrl+C` to each `mirrord exec` process, or stop the background task that launched it.
+
+### Confirm cleanup
+
+```bash
+pgrep -af "mirrord exec.*apps/shop" || echo "no shop mirrord exec processes"
+```
+
+During Phase 7 internal iteration, restart mirrord only as needed for the next validation run, and
+stop it again before the final report.
+
+## Phase 9: Report Back
 
 Return one concise report containing:
 
@@ -250,6 +278,7 @@ Return one concise report containing:
 - Failed checks, if any
 - Screenshot paths with one-line observations
 - Brief iteration notes if more than one attempt was needed
+- Confirmation that all mirrord sessions were stopped
 
 End with the developer choice set:
 
@@ -269,3 +298,4 @@ End with the developer choice set:
 - Never use unfiltered staging responses as proof that local code works.
 - Never validate frontend changes against `localhost` or `127.0.0.1`; run
   `metal-mart-frontend` under mirrord and use the public shop URL with baggage.
+- Never leave mirrord running after verification or handoff; stop every session before Phase 9.

--- a/.cursor/skills/mirrord-run-shop/SKILL.md
+++ b/.cursor/skills/mirrord-run-shop/SKILL.md
@@ -268,6 +268,37 @@ Do not mark shop or inventory work verified until all of the following hold:
 - Screenshots reviewed; product images visibly load on `/shop/products` and affected detail pages
 - Playwright screenshots staged and embedded in the PR body when a PR is opened or updated
 - No unauthorized writes to shared cluster databases
+- Every mirrord session started for this work has been stopped (see **Stop mirrord** below)
+
+## Stop mirrord
+
+Stop mirrord as soon as verification is done. Do not leave local mirrord processes running after
+handoff — they keep stealing filtered traffic on the shared playground cluster.
+
+### tmux sessions
+
+Kill each service session you started:
+
+```bash
+TMUX_CONFIG="/exec-daemon/tmux.portal.conf"
+if [ ! -f "$TMUX_CONFIG" ]; then TMUX_CONFIG="/dev/null"; fi
+tmux -f "$TMUX_CONFIG" kill-session -t "<service>-mirrord" 2>/dev/null || true
+```
+
+Repeat for every `<service>-mirrord` session (inventory, order, frontend, etc.).
+
+### Foreground or background shell
+
+Send `Ctrl+C` to the `mirrord exec` process, or stop the background Bash task that launched it.
+
+### Confirm cleanup
+
+```bash
+pgrep -af "mirrord exec.*apps/shop" || echo "no shop mirrord exec processes"
+```
+
+Do not mark the task complete, open the PR as ready, or report handoff while mirrord is still
+running.
 
 ## Inventory-Specific
 
@@ -276,9 +307,11 @@ and `.cursor/rules/01-no-staging-api-without-mirrord.mdc`.
 
 ## Handoff Block
 
+Only after stopping mirrord:
+
 ```text
-✓ <service> running under mirrord (session: ${MIRRORD_SESSION})
-  Header: baggage: mirrord-session=${MIRRORD_SESSION}
+✓ <service> verified under mirrord (session: ${MIRRORD_SESSION}); mirrord stopped
+  Header used: baggage: mirrord-session=${MIRRORD_SESSION}
   Playwright: /tmp/screenshots/mirrord-run-results.json
   Screenshots: /tmp/screenshots/mirrord-run-products.png
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Use this file and `docs/` for project context when working in this repo.
 The shared cluster at `https://playground.metalbear.dev` is staging. When verifying or fixing shop work:
 
 - **Do not use `kubectl port-forward`** (or similar) into `shop` or `infra` workloads as a substitute for mirrord or local-only testing. Use `mirrord exec` with the service `mirrord.json` and session-filtered traffic through the public shop URL, or run services locally (see `.cursor/skills/mirrord-run-shop/SKILL.md`).
+- **Stop mirrord when finishing work** — kill tmux sessions or `mirrord exec` processes after verification; do not leave them running on handoff (see **Stop mirrord** in `.cursor/skills/mirrord-run-shop/SKILL.md`).
 - **Do not alter the playground/staging database** without explicit human permission. No ad-hoc `kubectl exec` into Postgres, no manual `UPDATE`/`INSERT`/`DELETE` against shared `inventory`, `orders`, or other demo DBs to “fix” or “test” data. Validate through mirrord + public APIs and Playwright; put repairs in service code on your branch if data must be normalized at runtime.
 
 ## Build and deploy


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates mirrord skills, rules, and command docs so agents stop local mirrord sessions after verification instead of leaving them running on the shared playground cluster.

## Changes

- **`.cursor/skills/mirrord-run-shop/SKILL.md`**: Added **Stop mirrord** section with tmux/foreground cleanup commands and `pgrep` confirmation; added cleanup to completion criteria; handoff block now states mirrord was stopped.
- **`.cursor/skills/mirrord-agent-shop/SKILL.md`**: Added **Phase 8: Stop mirrord** before report-back; renumbered report to Phase 9; added guardrail and report confirmation.
- **`.cursor/rules/00-mirrord-inventory-service.mdc`**: Added stop-mirrord requirement to completion criteria with inventory-specific tmux kill commands.
- **`.cursor/rules/01-no-staging-api-without-mirrord.mdc`**: Completion section now requires stopping mirrord after verification.
- **`.claude/commands/mirrord-run.md`**: Replaced "do not auto-stop" with mandatory cleanup on finish; Phase 6 now stops mirrord before handoff.
- **`AGENTS.md`**: Added playground guardrail bullet for stopping mirrord on handoff.

## Why

Leaving mirrord running after agent work keeps stealing filtered traffic (`baggage: mirrord-session=...`) on the shared staging cluster, which can confuse other developers and agents.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8db5e58-f429-4743-9ffb-37a6ec63cc8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8db5e58-f429-4743-9ffb-37a6ec63cc8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

