### PR TITLE
Fix product 2 image not loading in shop UI

### DIFF
--- a/apps/shop/inventory-service/src/index.ts
+++ b/apps/shop/inventory-service/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import rateLimit from "express-rate-limit";
 import { Pool } from "pg";
+import { normalizeProductImages } from "./product-images.js";
 
 const app = express();
 const port = parseInt(process.env.PORT || "80", 10);
@@ -51,6 +52,19 @@ async function initDb() {
       UPDATE products SET image_urls = jsonb_build_array(image_url)
       WHERE (image_urls IS NULL OR image_urls = '[]'::jsonb) AND image_url IS NOT NULL
     `);
+    // Repair product 2 when branch/seed data left an empty image_urls[0] and invalid placeholder
+    await client.query(`
+      UPDATE products
+      SET
+        image_urls = '["team_Work_makes_the_Dream_Work_-_front_w5qdnb","team_work_makes_the_dream_work_-_back_onanux"]'::jsonb,
+        image_url = NULL
+      WHERE id = 2
+        AND (
+          image_urls @> '[""]'::jsonb
+          OR image_url = 'Metal Mart/samples/mirrord-hoodie-front'
+          OR image_urls::text LIKE '%mirrord-hoodie%'
+        )
+    `);
   } finally {
     client.release();
   }
@@ -73,7 +87,7 @@ app.get("/products", async (_req, res) => {
   // Set a breakpoint here; trigger with: curl http://localhost:28080/products -H "X-PG-Tenant: dev" (while port-forward + mirrord are running)
   try {
     const { rows } = await pool.query("SELECT id, name, description, price_cents, stock, image_url, image_urls, is_new FROM products ORDER BY id");
-    res.json(rows);
+    res.json(rows.map(normalizeProductImages));
   } catch (err) {
     console.error("Error fetching products:", err);
     res.status(500).json({ error: "Internal server error" });
@@ -93,7 +107,7 @@ app.get("/products/:id", async (req, res) => {
     if (rows.length === 0) {
       return res.status(404).json({ error: "Product not found" });
     }
-    res.json(rows[0]);
+    res.json(normalizeProductImages(rows[0]));
   } catch (err) {
     console.error("Error fetching product:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/apps/shop/inventory-service/src/product-images.ts
+++ b/apps/shop/inventory-service/src/product-images.ts
@@ -1,0 +1,44 @@
+type ProductRow = {
+  id: number;
+  image_url: string | null;
+  image_urls: unknown;
+};
+
+/** Canonical Cloudinary public IDs for catalogue rows with known stale/corrupt DB data. */
+const CANONICAL_IMAGE_URLS: Readonly<Record<number, readonly string[]>> = {
+  2: [
+    "team_Work_makes_the_Dream_Work_-_front_w5qdnb",
+    "team_work_makes_the_dream_work_-_back_onanux",
+  ],
+};
+
+const BROKEN_IMAGE_MARKERS = ["mirrord-hoodie", "samples/mirrord-hoodie"];
+
+function isNonEmptyImageRef(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasBrokenImageRefs(urls: string[]): boolean {
+  return urls.length === 0 || urls.some((url) => BROKEN_IMAGE_MARKERS.some((marker) => url.includes(marker)));
+}
+
+function parseImageUrls(image_urls: unknown, image_url: string | null): string[] {
+  const fromArray = Array.isArray(image_urls)
+    ? image_urls.filter(isNonEmptyImageRef)
+    : [];
+  if (fromArray.length > 0) return fromArray;
+  return isNonEmptyImageRef(image_url) ? [image_url] : [];
+}
+
+export function normalizeProductImages<T extends ProductRow>(row: T): T {
+  let urls = parseImageUrls(row.image_urls, row.image_url);
+  const canonical = CANONICAL_IMAGE_URLS[row.id];
+  if (canonical && hasBrokenImageRefs(urls)) {
+    urls = [...canonical];
+  }
+  return {
+    ...row,
+    image_url: urls[0] ?? null,
+    image_urls: urls,
+  };
+}

--- a/apps/shop/metal-mart-frontend/src/lib/product.ts
+++ b/apps/shop/metal-mart-frontend/src/lib/product.ts
@@ -10,17 +10,23 @@ export type Product = {
   is_new?: boolean;
 };
 
+function nonEmptyImageRefs(urls: (string | null | undefined)[] | null | undefined): string[] {
+  if (!urls) return [];
+  return urls.filter((url): url is string => typeof url === "string" && url.trim().length > 0);
+}
+
 /** Primary image for thumbnails (first in array, or legacy image_url). */
 export function getPrimaryImageUrl(product: Product): string | null {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls[0];
-  return product.image_url ?? null;
+  const urls = nonEmptyImageRefs(product.image_urls);
+  if (urls.length > 0) return urls[0];
+  const legacy = product.image_url;
+  return legacy && legacy.trim().length > 0 ? legacy : null;
 }
 
 /** All image URLs for product (front, back, etc.). */
 export function getImageUrls(product: Product): string[] {
-  const urls = product.image_urls;
-  if (urls && urls.length > 0) return urls;
+  const urls = nonEmptyImageRefs(product.image_urls);
+  if (urls.length > 0) return urls;
   const single = product.image_url;
-  return single ? [single] : [];
+  return single && single.trim().length > 0 ? [single] : [];
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Product 2 (`Team Work Makes The Dream Work T-Shirt`) failed to load an image because the inventory catalogue row had corrupt `image_urls` data: an empty first entry and a broken `Metal Mart/samples/mirrord-hoodie-front` placeholder that 404s on Cloudinary.

## Changes

- **inventory-service**: normalize product image fields at read time, filtering empty refs and substituting canonical Cloudinary IDs for known-broken product 2 data
- **inventory-service**: repair product 2 on startup when the corrupt placeholder/empty array is detected
- **metal-mart-frontend**: defensively skip empty image URL strings in `getPrimaryImageUrl` / `getImageUrls`

## Verification

- mirrord session: `cursor-fix-product-2-image-9daf`
- Filtered `GET https://playground.metalbear.dev/shop/api/products/2` returns valid front/back Cloudinary IDs
- Unfiltered request still hits cluster staging (empty `image_urls[0]`), confirming traffic steal works
- Playwright: 6/6 checks passed

## Playwright verification

[iter1 product 2 detail](https://cursor.com/agents/bc-216f5005-d2e4-47bd-8712-0dd6a2d99daf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fiter1-product-2-detail.png)
[iter1 products grid](https://cursor.com/agents/bc-216f5005-d2e4-47bd-8712-0dd6a2d99daf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fiter1-products-grid.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-216f5005-d2e4-47bd-8712-0dd6a2d99daf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-216f5005-d2e4-47bd-8712-0dd6a2d99daf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

