### PR TITLE
Add light/dark mode toggle to MetalMart shop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@
 | `LoadingSpinner.tsx` | Centered loading spinner. |
 | `Mascot.tsx` / `MascotPositioned.tsx` | MetalBear mascot decoration. |
 | `DecorativeIcons.tsx` | Decorative icons. |
+| `ThemeToggle.tsx` | Light/dark theme toggle in the header. Persists choice in `localStorage` (`metal-mart-theme`); toggles the `dark` class on `<html>`. |
 
 ### Data model (`src/lib/product.ts`)
 
@@ -65,6 +66,7 @@ Helper functions: `getPrimaryImageUrl(product)` returns first image, `getImageUr
 - `.hand-drawn-underline` class for MetalBear-style orange underline on headings
 - Base path support via `NEXT_BASE_PATH` env var and `NEXT_PUBLIC_BASE_PATH` for client-side fetches
 - Cloudinary for product images via `NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME` env var
+- Dark mode: class-based (`dark` on `<html>`) via the `@custom-variant dark` in `globals.css`. Dark palette overrides the CSS variables under `.dark`; components use `dark:` utility variants. An inline script in `layout.tsx` applies the saved/system theme before paint to avoid a flash. Toggled by `ThemeToggle`.
 
 ### Backend services
 

--- a/apps/shop/metal-mart-frontend/src/app/cart/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/cart/page.tsx
@@ -52,7 +52,7 @@ export default function CartPage() {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen flex-col bg-white">
+      <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
         <Header />
         <main className="flex-1 p-8">
           <LoadingSpinner />
@@ -62,16 +62,16 @@ export default function CartPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
+    <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
       <Header />
       <main className="flex-1 px-6 py-8">
         <div className="mx-auto max-w-3xl">
-          <h1 className="hand-drawn-underline mb-8 inline-block text-2xl font-bold tracking-tight text-slate-900">
+          <h1 className="hand-drawn-underline mb-8 inline-block text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
             Cart
           </h1>
           {cart.length === 0 ? (
-            <div className="rounded-xl border border-slate-300 bg-slate-50 px-8 py-16 text-center">
-              <p className="text-lg text-slate-600">Your cart is empty.</p>
+            <div className="rounded-xl border border-slate-300 bg-slate-50 px-8 py-16 text-center dark:border-slate-700 dark:bg-slate-900">
+              <p className="text-lg text-slate-600 dark:text-slate-400">Your cart is empty.</p>
               <Link
                 href="/products"
                 className="btn-primary mt-6 inline-block rounded-xl px-6 py-2.5 font-medium focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
@@ -85,9 +85,9 @@ export default function CartPage() {
                 {cart.map((i) => (
                   <li
                     key={i.productId}
-                    className="flex items-center gap-5 rounded-xl border border-slate-300 bg-white p-4 shadow-sm transition-all duration-200 hover:shadow-md hover:border-[#6a4ff5]/20"
+                    className="flex items-center gap-5 rounded-xl border border-slate-300 bg-white p-4 shadow-sm transition-all duration-200 hover:shadow-md hover:border-[#6a4ff5]/20 dark:border-slate-700 dark:bg-slate-900"
                   >
-                    <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-lg bg-slate-100">
+                    <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-lg bg-slate-100 dark:bg-slate-800">
                       {i.product && getPrimaryImageUrl(i.product) ? (
                         <ProductImage
                           src={getPrimaryImageUrl(i.product)!}
@@ -103,7 +103,7 @@ export default function CartPage() {
                       )}
                     </div>
                     <div className="min-w-0 flex-1">
-                      <span className="font-medium text-slate-900">
+                      <span className="font-medium text-slate-900 dark:text-slate-100">
                         {i.product?.name ?? `Product ${i.productId}`}
                       </span>
                     </div>
@@ -113,14 +113,14 @@ export default function CartPage() {
                     <div className="flex shrink-0 items-center gap-2">
                       <button
                         onClick={() => updateQty(i.productId, -1)}
-                        className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium hover:bg-slate-50 hover:border-[#6a4ff5]/30 focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40"
+                        className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium hover:bg-slate-50 hover:border-[#6a4ff5]/30 focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
                       >
                         −
                       </button>
-                      <span className="min-w-[1.5rem] text-center font-medium text-slate-900">{i.quantity}</span>
+                      <span className="min-w-[1.5rem] text-center font-medium text-slate-900 dark:text-slate-100">{i.quantity}</span>
                       <button
                         onClick={() => updateQty(i.productId, 1)}
-                        className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium hover:bg-slate-50 hover:border-[#6a4ff5]/30 focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40"
+                        className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium hover:bg-slate-50 hover:border-[#6a4ff5]/30 focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
                       >
                         +
                       </button>
@@ -129,7 +129,7 @@ export default function CartPage() {
                 ))}
               </ul>
               <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                <p className="text-xl font-semibold text-slate-900">
+                <p className="text-xl font-semibold text-slate-900 dark:text-slate-100">
                   Total: ${(totalCents / 100).toFixed(2)}
                 </p>
                 <Link

--- a/apps/shop/metal-mart-frontend/src/app/checkout/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/checkout/page.tsx
@@ -63,7 +63,7 @@ export default function CheckoutPage() {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen flex-col bg-white">
+      <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
         <Header />
         <main className="flex-1 p-8">
           <LoadingSpinner />
@@ -74,12 +74,12 @@ export default function CheckoutPage() {
 
   if (orderId) {
     return (
-      <div className="flex min-h-screen flex-col bg-white">
+      <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
         <Header />
         <main className="flex flex-1 flex-col items-center justify-center gap-6 px-6 py-16">
-          <div className="rounded-full bg-green-100 p-4">
+          <div className="rounded-full bg-green-100 p-4 dark:bg-green-950/40">
             <svg
-              className="h-12 w-12 text-green-600"
+              className="h-12 w-12 text-green-600 dark:text-green-400"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -88,8 +88,8 @@ export default function CheckoutPage() {
               <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
             </svg>
           </div>
-          <h1 className="text-2xl font-bold text-green-600">Order placed!</h1>
-          <p className="text-slate-600">Order ID: {orderId}</p>
+          <h1 className="text-2xl font-bold text-green-600 dark:text-green-400">Order placed!</h1>
+          <p className="text-slate-600 dark:text-slate-400">Order ID: {orderId}</p>
           <Link
             href={`/orders/${orderId}`}
             className="btn-primary rounded-xl px-8 py-3 font-semibold focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
@@ -103,11 +103,11 @@ export default function CheckoutPage() {
 
   if (cart.length === 0) {
     return (
-      <div className="flex min-h-screen flex-col bg-white">
+      <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
         <Header />
         <main className="flex flex-1 items-center justify-center px-6 py-16">
-          <div className="rounded-xl border border-slate-300 bg-slate-50 px-8 py-16 text-center">
-            <p className="text-lg text-slate-600">Cart is empty. Add items first.</p>
+          <div className="rounded-xl border border-slate-300 bg-slate-50 px-8 py-16 text-center dark:border-slate-700 dark:bg-slate-900">
+            <p className="text-lg text-slate-600 dark:text-slate-400">Cart is empty. Add items first.</p>
             <Link
               href="/products"
               className="btn-primary mt-6 inline-block rounded-xl px-6 py-2.5 font-medium focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2"
@@ -121,17 +121,17 @@ export default function CheckoutPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
+    <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
       <Header />
       <main className="flex-1 px-6 py-8">
         <div className="mx-auto max-w-2xl">
-          <h1 className="hand-drawn-underline mb-8 inline-block text-2xl font-bold tracking-tight text-slate-900">
+          <h1 className="hand-drawn-underline mb-8 inline-block text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
             Checkout
           </h1>
-          <ul className="mb-6 space-y-3 rounded-xl border border-slate-300 bg-slate-50 p-5">
+          <ul className="mb-6 space-y-3 rounded-xl border border-slate-300 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900">
             {cart.map((i) => (
               <li key={i.productId} className="flex items-center justify-between">
-                <span className="text-slate-700">
+                <span className="text-slate-700 dark:text-slate-300">
                   {i.product?.name ?? `Product ${i.productId}`} × {i.quantity}
                 </span>
                 <span className="font-semibold text-[#6a4ff5]">
@@ -140,11 +140,11 @@ export default function CheckoutPage() {
               </li>
             ))}
           </ul>
-          <p className="mb-6 text-xl font-semibold text-slate-900">
+          <p className="mb-6 text-xl font-semibold text-slate-900 dark:text-slate-100">
             Total: ${(totalCents / 100).toFixed(2)}
           </p>
           <div className="mb-6">
-            <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-slate-700">
+            <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
               Email <span className="text-slate-400">(optional)</span>
             </label>
             <input
@@ -153,12 +153,12 @@ export default function CheckoutPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
-              className="w-full rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-slate-900 placeholder-slate-400 focus:border-[#6a4ff5] focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/20"
+              className="w-full rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-slate-900 placeholder-slate-400 focus:border-[#6a4ff5] focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/20 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder-slate-500"
             />
           </div>
           {error && (
             <p
-              className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600"
+              className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600 dark:border-red-900 dark:bg-red-950/40 dark:text-red-400"
               role="alert"
             >
               {error}

--- a/apps/shop/metal-mart-frontend/src/app/debug-cloudinary/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/debug-cloudinary/page.tsx
@@ -18,10 +18,10 @@ export default function DebugCloudinaryPage() {
 
   if (!cloudName) {
     return (
-      <div className="min-h-screen bg-slate-50 p-8">
+      <div className="min-h-screen bg-slate-50 p-8 dark:bg-slate-950">
         <div className="mx-auto max-w-2xl space-y-4">
-          <h1 className="text-2xl font-bold text-slate-900">Cloudinary Debug</h1>
-          <p className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-800">
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Cloudinary Debug</h1>
+          <p className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-800 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300">
             <strong>NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME</strong> is not set. Add it to .env.local and restart the dev server.
           </p>
           <Link href={basePath || "/"} className="text-[#6a4ff5] hover:underline">
@@ -33,27 +33,27 @@ export default function DebugCloudinaryPage() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 p-8">
+    <div className="min-h-screen bg-slate-50 p-8 dark:bg-slate-950">
       <div className="mx-auto max-w-2xl space-y-8">
         <div>
-          <h1 className="text-2xl font-bold text-slate-900">Cloudinary Debug</h1>
-          <p className="mt-1 text-sm text-slate-600">
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Cloudinary Debug</h1>
+          <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
             Use this page to verify URLs. Click a link to test in a new tab — if it 404s, the public_id or folder is wrong.
           </p>
         </div>
 
-        <div className="rounded-xl border border-slate-200 bg-white p-5 space-y-2">
-          <h2 className="font-semibold text-slate-900">Config</h2>
+        <div className="rounded-xl border border-slate-200 bg-white p-5 space-y-2 dark:border-slate-800 dark:bg-slate-900">
+          <h2 className="font-semibold text-slate-900 dark:text-slate-100">Config</h2>
           <dl className="text-sm">
             <dt className="text-slate-500">Cloud name</dt>
-            <dd className="font-mono text-slate-900">{cloudName}</dd>
+            <dd className="font-mono text-slate-900 dark:text-slate-100">{cloudName}</dd>
             <dt className="mt-2 text-slate-500">Folder prefix</dt>
-            <dd className="font-mono text-slate-900">{folderPrefix || "(none)"}</dd>
+            <dd className="font-mono text-slate-900 dark:text-slate-100">{folderPrefix || "(none)"}</dd>
           </dl>
         </div>
 
         <div className="space-y-6">
-          <h2 className="font-semibold text-slate-900">Test URLs</h2>
+          <h2 className="font-semibold text-slate-900 dark:text-slate-100">Test URLs</h2>
           {TEST_IDS.map((rawId) => {
             const resolvedId = resolveCloudinaryId(rawId);
             const url = getCldImageUrl(
@@ -63,10 +63,10 @@ export default function DebugCloudinaryPage() {
             return (
               <div
                 key={rawId}
-                className="rounded-xl border border-slate-200 bg-white p-5 space-y-2"
+                className="rounded-xl border border-slate-200 bg-white p-5 space-y-2 dark:border-slate-800 dark:bg-slate-900"
               >
-                <p className="text-sm font-medium text-slate-700">Raw ID: {rawId}</p>
-                <p className="text-sm font-medium text-slate-700">
+                <p className="text-sm font-medium text-slate-700 dark:text-slate-300">Raw ID: {rawId}</p>
+                <p className="text-sm font-medium text-slate-700 dark:text-slate-300">
                   Resolved ID: {resolvedId}
                   {resolvedId !== rawId && (
                     <span className="ml-2 text-slate-500">(prefix applied)</span>
@@ -87,7 +87,7 @@ export default function DebugCloudinaryPage() {
                   <img
                     src={url}
                     alt=""
-                    className="h-24 w-24 object-contain border border-slate-200 rounded"
+                    className="h-24 w-24 object-contain border border-slate-200 rounded dark:border-slate-700"
                     onError={(e) => {
                       (e.target as HTMLImageElement).alt = "Failed to load";
                       (e.target as HTMLImageElement).src = "";
@@ -100,8 +100,8 @@ export default function DebugCloudinaryPage() {
           })}
         </div>
 
-        <div className="rounded-xl border border-slate-200 bg-slate-100 p-5 text-sm text-slate-700">
-          <h3 className="font-semibold text-slate-900 mb-2">If images 404</h3>
+        <div className="rounded-xl border border-slate-200 bg-slate-100 p-5 text-sm text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+          <h3 className="font-semibold text-slate-900 dark:text-slate-100 mb-2">If images 404</h3>
           <ul className="list-disc list-inside space-y-1">
             <li>In Cloudinary Media Library, click an asset and copy the <strong>Public ID</strong> exactly.</li>
             <li>If the Public ID includes the folder (e.g. <code>Metal Mart/team_work_...</code>), set <code>NEXT_PUBLIC_CLOUDINARY_FOLDER_PREFIX</code> to empty and store the full ID in the DB.</li>

--- a/apps/shop/metal-mart-frontend/src/app/globals.css
+++ b/apps/shop/metal-mart-frontend/src/app/globals.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+/* Class-based dark mode: toggled via the `dark` class on <html> (see ThemeToggle). */
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* MetalBear-inspired palette */
 :root {
   --background: #ffffff;
@@ -12,16 +15,35 @@
   --orange-hover: #fbbf24;
 }
 
+/* Dark mode palette */
+.dark {
+  --background: #0a0a14;
+  --foreground: #e8e8f0;
+  --muted: #94a3b8;
+  /* Brighter purple reads better on dark surfaces */
+  --purple: #8b75f7;
+  --purple-hover: #9d8bf9;
+  --purple-light: #2a2350;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-dm-sans), ui-sans-serif, system-ui, sans-serif;
 }
 
+html {
+  color-scheme: light;
+}
+html.dark {
+  color-scheme: dark;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
   font-feature-settings: "rlig" 1, "calt" 1;
+  transition: background-color 0.25s ease, color 0.25s ease;
 }
 
 /* Smooth transitions for interactive elements */

--- a/apps/shop/metal-mart-frontend/src/app/layout.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/layout.tsx
@@ -14,13 +14,27 @@ export const metadata: Metadata = {
   description: "Official MetalBear merchandise",
 };
 
+// Applies the saved theme (or system preference) before paint to avoid a flash of the wrong theme.
+const themeInitScript = `
+(function () {
+  try {
+    var stored = localStorage.getItem("metal-mart-theme");
+    var dark = stored ? stored === "dark" : window.matchMedia("(prefers-color-scheme: dark)").matches;
+    if (dark) document.documentElement.classList.add("dark");
+  } catch (e) {}
+})();
+`;
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={dmSans.variable}>
+    <html lang="en" className={dmSans.variable} suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body className="min-h-screen antialiased font-sans">
         <div className="relative min-h-screen flex flex-col">
           <MascotPositioned />

--- a/apps/shop/metal-mart-frontend/src/app/orders/[id]/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/orders/[id]/page.tsx
@@ -65,7 +65,7 @@ export default function OrderPage() {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen flex-col bg-white">
+      <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
         <Header />
         <main className="flex-1 p-8">
           <LoadingSpinner />
@@ -75,16 +75,16 @@ export default function OrderPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
+    <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
       <Header />
       <main className="flex-1 px-6 py-8">
         <div className="mx-auto max-w-2xl">
-          <h1 className="mb-8 text-2xl font-bold tracking-tight text-slate-900">
+          <h1 className="mb-8 text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
             Order #{order?.id ?? id ?? "—"}
           </h1>
           {error && (
             <p
-              className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600"
+              className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600 dark:border-red-900 dark:bg-red-950/40 dark:text-red-400"
               role="alert"
             >
               {error}
@@ -92,25 +92,25 @@ export default function OrderPage() {
           )}
           {order ? (
             <div className="space-y-8">
-              <div className="rounded-xl border border-slate-200 bg-slate-50 p-5 space-y-2">
+              <div className="rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-900 p-5 space-y-2">
                 <p>
                   Status: <span className="font-medium text-[#6a4ff5]">{order.status}</span>
                 </p>
-                <p className="text-slate-600">
+                <p className="text-slate-600 dark:text-slate-400">
                   Placed: {new Date(order.created_at).toLocaleString()}
                 </p>
                 {delivery && (
-                  <p className="text-slate-600">Delivery: {delivery.status}</p>
+                  <p className="text-slate-600 dark:text-slate-400">Delivery: {delivery.status}</p>
                 )}
               </div>
               {lineItems.length > 0 && (
                 <div>
-                  <h2 className="mb-3 text-lg font-semibold text-slate-900">Items</h2>
-                  <ul className="space-y-3 rounded-xl border border-slate-200 bg-slate-50 p-5">
+                  <h2 className="mb-3 text-lg font-semibold text-slate-900 dark:text-slate-100">Items</h2>
+                  <ul className="space-y-3 rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-900 p-5">
                     {lineItems.map(({ product, quantity }) => (
                       <li
                         key={product.id}
-                        className="flex justify-between text-slate-700"
+                        className="flex justify-between text-slate-700 dark:text-slate-300"
                       >
                         <span>{product.name} × {quantity}</span>
                         <span className="font-semibold text-[#6a4ff5]">
@@ -119,15 +119,15 @@ export default function OrderPage() {
                       </li>
                     ))}
                   </ul>
-                  <p className="mt-3 text-lg font-semibold text-slate-900">
+                  <p className="mt-3 text-lg font-semibold text-slate-900 dark:text-slate-100">
                     Total: ${(order.total_cents / 100).toFixed(2)}
                   </p>
                 </div>
               )}
             </div>
           ) : !error ? (
-            <div className="rounded-xl border border-slate-200 bg-slate-50 px-8 py-16 text-center">
-              <p className="text-slate-600">Order not found</p>
+            <div className="rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-900 px-8 py-16 text-center">
+              <p className="text-slate-600 dark:text-slate-400">Order not found</p>
               <Link
                 href="/products"
                 className="mt-6 inline-block text-[#6a4ff5] hover:text-[#5a3fe5]"

--- a/apps/shop/metal-mart-frontend/src/app/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/page.tsx
@@ -31,7 +31,7 @@ function ProductTile({
     return (
       <Link
         href={href}
-        className={`group relative flex h-full min-h-[280px] flex-col overflow-hidden rounded-2xl border border-slate-300 bg-slate-100 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-[#6a4ff5]/15 hover:border-[#6a4ff5]/30 animate-card-reveal ${elevatedClass}`}
+        className={`group relative flex h-full min-h-[280px] flex-col overflow-hidden rounded-2xl border border-slate-300 bg-slate-100 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-[#6a4ff5]/15 hover:border-[#6a4ff5]/30 animate-card-reveal dark:border-slate-700 dark:bg-slate-800 ${elevatedClass}`}
         style={{ animationDelay: `${delay}s` }}
       >
         {product.is_new && <NewBadge size="default" />}
@@ -45,7 +45,7 @@ function ProductTile({
               sizes="(max-width: 768px) 100vw, 50vw"
             />
           ) : (
-            <div className="flex h-full w-full items-center justify-center bg-slate-200 text-slate-400">
+            <div className="flex h-full w-full items-center justify-center bg-slate-200 text-slate-400 dark:bg-slate-800">
               No image
             </div>
           )}
@@ -68,11 +68,11 @@ function ProductTile({
     return (
       <Link
         href={href}
-        className={`group relative flex flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal sm:flex-row ${elevatedClass}`}
+        className={`group relative flex flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900 transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal sm:flex-row ${elevatedClass}`}
         style={{ animationDelay: `${delay}s` }}
       >
         {product.is_new && <NewBadge size="default" />}
-        <div className="relative aspect-square w-full shrink-0 overflow-hidden bg-slate-100 sm:aspect-[4/3] sm:w-64">
+        <div className="relative aspect-square w-full shrink-0 overflow-hidden bg-slate-100 dark:bg-slate-800 sm:aspect-[4/3] sm:w-64">
           {getPrimaryImageUrl(product) ? (
             <ProductImage
               src={getPrimaryImageUrl(product)!}
@@ -88,12 +88,12 @@ function ProductTile({
           )}
         </div>
         <div className="flex flex-1 flex-col justify-center p-6">
-          <h2 className="text-xl font-bold text-slate-900 group-hover:text-[#6a4ff5] transition-colors">
+          <h2 className="text-xl font-bold text-slate-900 group-hover:text-[#6a4ff5] transition-colors dark:text-slate-100">
             {product.name}
           </h2>
           <p className="mt-1 text-lg font-semibold text-[#6a4ff5]">{price}</p>
           {product.description && (
-            <p className="mt-2 line-clamp-2 text-sm text-slate-600">
+            <p className="mt-2 line-clamp-2 text-sm text-slate-600 dark:text-slate-400">
               {product.description}
             </p>
           )}
@@ -106,11 +106,11 @@ function ProductTile({
   return (
     <Link
       href={href}
-      className={`group relative flex flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal ${elevatedClass}`}
+      className={`group relative flex flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900 transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal ${elevatedClass}`}
       style={{ animationDelay: `${delay}s` }}
     >
       {product.is_new && <NewBadge size="default" />}
-      <div className="relative aspect-square overflow-hidden bg-slate-100">
+      <div className="relative aspect-square overflow-hidden bg-slate-100 dark:bg-slate-800">
         {getPrimaryImageUrl(product) ? (
           <ProductImage
             src={getPrimaryImageUrl(product)!}
@@ -126,7 +126,7 @@ function ProductTile({
         )}
       </div>
       <div className="flex flex-1 flex-col p-4">
-        <h2 className="font-semibold text-slate-900 group-hover:text-[#6a4ff5] transition-colors">
+        <h2 className="font-semibold text-slate-900 group-hover:text-[#6a4ff5] transition-colors dark:text-slate-100">
           {product.name}
         </h2>
         <p className="mt-1 font-semibold text-[#6a4ff5]">{price}</p>
@@ -150,7 +150,7 @@ export default function Home() {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen flex-col bg-white">
+      <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
         <Header showSubtitle />
         <main className="flex flex-1 items-center justify-center p-8">
           <LoadingSpinner />
@@ -161,10 +161,10 @@ export default function Home() {
 
   if (error) {
     return (
-      <div className="flex min-h-screen flex-col bg-white">
+      <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
         <Header showSubtitle />
         <main className="flex flex-1 items-center justify-center p-8">
-          <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600">
+          <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600 dark:border-red-900 dark:bg-red-950/40 dark:text-red-400">
             Error: {error}
           </p>
         </main>
@@ -177,14 +177,14 @@ export default function Home() {
   const hasMultipleProducts = products.length > 1;
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
+    <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
       <Header showSubtitle />
       <main className="flex flex-1 flex-col">
         {/* Bento product grid */}
         <section className="flex-1 px-6 py-12">
           <div className="mx-auto max-w-6xl">
             {hasProducts && (
-              <h1 className="hand-drawn-underline mb-10 inline-block text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl md:text-5xl">
+              <h1 className="hand-drawn-underline mb-10 inline-block text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-100 sm:text-4xl md:text-5xl">
                 Featured products
               </h1>
             )}
@@ -255,8 +255,8 @@ export default function Home() {
                 </div>
               </>
             ) : (
-              <div className="rounded-2xl border border-slate-300 bg-slate-50 px-8 py-16 text-center">
-                <p className="text-slate-600">No products yet.</p>
+              <div className="rounded-2xl border border-slate-300 bg-slate-50 px-8 py-16 text-center dark:border-slate-700 dark:bg-slate-900">
+                <p className="text-slate-600 dark:text-slate-400">No products yet.</p>
                 <Link
                   href="/products"
                   className="btn-primary mt-4 inline-block rounded-xl px-6 py-2.5 text-sm font-medium"

--- a/apps/shop/metal-mart-frontend/src/app/products/[id]/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/[id]/page.tsx
@@ -37,7 +37,7 @@ export default function ProductDetailPage() {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen flex-col bg-white">
+      <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
         <Header />
         <main className="flex-1 p-8">
           <LoadingSpinner />
@@ -47,10 +47,10 @@ export default function ProductDetailPage() {
   }
   if (error || !product) {
     return (
-      <div className="flex min-h-screen flex-col bg-white">
+      <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
         <Header />
         <main className="flex-1 p-8">
-          <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600">
+          <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600 dark:border-red-900 dark:bg-red-950/40 dark:text-red-400">
             {error || "Product not found"}
           </p>
           <Link
@@ -68,13 +68,13 @@ export default function ProductDetailPage() {
   const labels = imageUrls.length === 2 ? ["Front", "Back"] : undefined;
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
+    <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
       <Header />
       <main className="flex-1 px-6 py-8">
         <div className="mx-auto max-w-5xl">
           <div className="grid gap-10 md:grid-cols-2">
             <div className="space-y-3">
-              <div className="relative aspect-square overflow-hidden rounded-xl border border-slate-200 bg-slate-50 shadow-lg">
+              <div className="relative aspect-square overflow-hidden rounded-xl border border-slate-200 bg-slate-50 shadow-lg dark:border-slate-800 dark:bg-slate-900">
                 {product.is_new && <NewBadge size="lg" />}
                 {imageUrls.length > 0 ? (
                   <ProductImage
@@ -100,7 +100,7 @@ export default function ProductDetailPage() {
                       className={`relative h-16 w-16 shrink-0 overflow-hidden rounded-lg border-2 transition-colors ${
                         selectedIndex === i
                           ? "border-[#6a4ff5] ring-2 ring-[#6a4ff5]/30"
-                          : "border-slate-200 hover:border-slate-300"
+                          : "border-slate-200 hover:border-slate-300 dark:border-slate-700 dark:hover:border-slate-600"
                       }`}
                       aria-label={labels ? labels[i] : `Image ${i + 1}`}
                     >
@@ -117,14 +117,14 @@ export default function ProductDetailPage() {
               )}
             </div>
             <div className="flex flex-col">
-              <h1 className="text-3xl font-bold tracking-tight text-slate-900">{product.name}</h1>
+              <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-100">{product.name}</h1>
               <p className="mt-3 text-2xl font-semibold text-[#6a4ff5]">
                 ${(product.price_cents / 100).toFixed(2)}
               </p>
               {product.description && (
-                <p className="mt-6 text-slate-600 leading-relaxed">{product.description}</p>
+                <p className="mt-6 text-slate-600 leading-relaxed dark:text-slate-400">{product.description}</p>
               )}
-              <p className="mt-4 text-sm text-slate-500">In stock: {product.stock}</p>
+              <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">In stock: {product.stock}</p>
               <div className="mt-10 flex flex-col gap-4 sm:flex-row">
                 <Link
                   href={`/cart?add=${product.id}`}

--- a/apps/shop/metal-mart-frontend/src/app/products/page.tsx
+++ b/apps/shop/metal-mart-frontend/src/app/products/page.tsx
@@ -25,7 +25,7 @@ export default function ProductsPage() {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen flex-col bg-white">
+      <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
         <Header />
         <main className="flex-1 p-8">
           <LoadingSpinner />
@@ -35,10 +35,10 @@ export default function ProductsPage() {
   }
   if (error) {
     return (
-      <div className="flex min-h-screen flex-col bg-white">
+      <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
         <Header />
         <main className="flex-1 p-8">
-          <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600">
+          <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600 dark:border-red-900 dark:bg-red-950/40 dark:text-red-400">
             Error: {error}
           </p>
         </main>
@@ -47,11 +47,11 @@ export default function ProductsPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
+    <div className="flex min-h-screen flex-col bg-white dark:bg-slate-950">
       <Header />
       <main className="flex-1 px-6 py-8">
         <div className="mx-auto max-w-6xl">
-          <h1 className="hand-drawn-underline mb-10 inline-block text-2xl font-bold tracking-tight text-slate-900">
+          <h1 className="hand-drawn-underline mb-10 inline-block text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
             Products
           </h1>
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
@@ -59,11 +59,11 @@ export default function ProductsPage() {
               <Link
                 key={p.id}
                 href={`/products/${p.id}`}
-                className="group relative flex flex-col overflow-hidden rounded-xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal"
+                className="group relative flex flex-col overflow-hidden rounded-xl border border-slate-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#6a4ff5]/30 hover:shadow-xl hover:shadow-[#6a4ff5]/10 animate-card-reveal dark:border-slate-700 dark:bg-slate-900"
                 style={{ animationDelay: `${i * 0.06}s` }}
               >
                 {p.is_new && <NewBadge size="default" />}
-                <div className="relative aspect-square overflow-hidden bg-slate-100">
+                <div className="relative aspect-square overflow-hidden bg-slate-100 dark:bg-slate-800">
                   {getPrimaryImageUrl(p) ? (
                     <ProductImage
                       src={getPrimaryImageUrl(p)!}
@@ -79,11 +79,11 @@ export default function ProductsPage() {
                   )}
                 </div>
                 <div className="flex flex-1 flex-col p-5">
-                  <h2 className="font-semibold text-slate-900 group-hover:text-[#6a4ff5] transition-colors">
+                  <h2 className="font-semibold text-slate-900 group-hover:text-[#6a4ff5] transition-colors dark:text-slate-100">
                     {p.name}
                   </h2>
                   <p className="mt-2 text-lg font-semibold text-[#6a4ff5]">${(p.price_cents / 100).toFixed(2)}</p>
-                  <p className="mt-auto pt-3 text-xs text-slate-500">In stock: {p.stock}</p>
+                  <p className="mt-auto pt-3 text-xs text-slate-500 dark:text-slate-400">In stock: {p.stock}</p>
                 </div>
               </Link>
             ))}

--- a/apps/shop/metal-mart-frontend/src/components/Header.tsx
+++ b/apps/shop/metal-mart-frontend/src/components/Header.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { CldImage } from "next-cloudinary";
 import { resolveCloudinaryId } from "@/lib/cloudinary";
+import ThemeToggle from "@/components/ThemeToggle";
 
 const METALBEAR_LOGO_ID = "MetalBear_logo_c2doft";
 
@@ -14,11 +15,11 @@ type HeaderProps = {
 export default function Header({ showSubtitle = false }: HeaderProps) {
   const cloudName = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
   return (
-    <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/95 backdrop-blur-sm">
+    <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/95 backdrop-blur-sm dark:border-slate-800 dark:bg-slate-950/95">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
         <Link
           href="/"
-          className="flex items-center gap-2 text-xl font-bold tracking-tight text-slate-900 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2 rounded"
+          className="flex items-center gap-2 text-xl font-bold tracking-tight text-slate-900 hover:text-slate-700 dark:text-slate-100 dark:hover:text-white focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40 focus:ring-offset-2 rounded"
         >
           {cloudName && (
             <CldImage
@@ -33,22 +34,23 @@ export default function Header({ showSubtitle = false }: HeaderProps) {
         </Link>
         <div className="flex items-center gap-8">
           {showSubtitle && (
-            <p className="hidden text-sm text-slate-600 sm:block">Official MetalBear Swag</p>
+            <p className="hidden text-sm text-slate-600 dark:text-slate-400 sm:block">Official MetalBear Swag</p>
           )}
           <nav className="flex gap-6" aria-label="Main navigation">
             <Link
               href="/products"
-              className="text-sm font-medium text-slate-600 hover:text-slate-900"
+              className="text-sm font-medium text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
             >
               Products
             </Link>
             <Link
               href="/cart"
-              className="text-sm font-medium text-slate-600 hover:text-slate-900"
+              className="text-sm font-medium text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
             >
               Cart
             </Link>
           </nav>
+          <ThemeToggle />
         </div>
       </div>
     </header>

--- a/apps/shop/metal-mart-frontend/src/components/LoadingSpinner.tsx
+++ b/apps/shop/metal-mart-frontend/src/components/LoadingSpinner.tsx
@@ -2,7 +2,7 @@ export default function LoadingSpinner() {
   return (
     <div className="flex min-h-[200px] items-center justify-center" aria-label="Loading">
       <div
-        className="h-8 w-8 animate-spin rounded-full border-2 border-slate-200 border-t-[#6a4ff5]"
+        className="h-8 w-8 animate-spin rounded-full border-2 border-slate-200 border-t-[#6a4ff5] dark:border-slate-700"
         role="status"
       />
     </div>

--- a/apps/shop/metal-mart-frontend/src/components/ThemeToggle.tsx
+++ b/apps/shop/metal-mart-frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "metal-mart-theme";
+
+/**
+ * Light/dark theme toggle. Persists the choice in localStorage (key `metal-mart-theme`);
+ * the initial theme is applied before paint by the inline script in layout.tsx, so this
+ * component only mirrors and updates that state.
+ */
+export default function ThemeToggle() {
+  const [mounted, setMounted] = useState(false);
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    setIsDark(document.documentElement.classList.contains("dark"));
+    setMounted(true);
+  }, []);
+
+  const toggle = () => {
+    const next = !isDark;
+    setIsDark(next);
+    document.documentElement.classList.toggle("dark", next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next ? "dark" : "light");
+    } catch {
+      /* ignore storage failures (e.g. private mode) */
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 text-slate-600 hover:text-slate-900 hover:border-[#6a4ff5]/30 dark:border-slate-700 dark:text-slate-400 dark:hover:text-slate-100 focus:outline-none focus:ring-2 focus:ring-[#6a4ff5]/40"
+    >
+      {/* Render a neutral icon until mounted to avoid hydration mismatch */}
+      {mounted && isDark ? (
+        // Sun
+        <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+        </svg>
+      ) : (
+        // Moon
+        <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## What

Adds a light/dark mode to the MetalMart frontend (`apps/shop/metal-mart-frontend`), toggled from the header.

## How

- **`ThemeToggle` component** (new) in the `Header`. Sun/moon button that toggles the `dark` class on `<html>`, persists the choice in `localStorage` under `metal-mart-theme`, and defaults to the OS `prefers-color-scheme` when nothing is stored.
- **No-flash init script** in `layout.tsx` applies the saved/system theme before paint, so there's no flash of the wrong theme on load (`suppressHydrationWarning` added to `<html>`).
- **`globals.css`**: registers a class-based `@custom-variant dark` and a dark palette that overrides the existing CSS variables (`--background`, `--foreground`, `--muted`, brighter `--purple` for dark surfaces). Sets `color-scheme` per mode and a smooth body transition.
- **Pages & components**: added `dark:` utility variants across the home, products, product detail, cart, checkout, order, and debug pages plus `Header`/`LoadingSpinner` so surfaces, text, borders, and status colors read well in dark mode. Imagery and the purple footer are unchanged.
- Updated `CLAUDE.md` (components table + styling notes).

## Testing

- `npm run build` passes (all 10 routes compile / prerender).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)