### PR TITLE
Change /orders response status to "confirmed inma"

### DIFF
--- a/apps/shop/order-service/src/index.ts
+++ b/apps/shop/order-service/src/index.ts
@@ -225,7 +225,7 @@ async function createOrderDirect(
     baggage,
   });
 
-  return { orderId, status: "confirmed" };
+  return { orderId, status: "confirmed inma" };
 }
 
 app.post("/orders", async (req, res) => {


### PR DESCRIPTION
## Summary
- Changed the `/orders` HTTP response in `createOrderDirect` so the returned `status` is `"confirmed inma"` instead of `"confirmed"`.

## Notes
- Only the HTTP response value was changed. The DB row status and the Kafka/RabbitMQ/PubSub event payloads still use `"confirmed"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)